### PR TITLE
DB에 물품 하드코딩으로 넣어보기

### DIFF
--- a/src/main/java/SilkLoad/controller/Product/ProductController.java
+++ b/src/main/java/SilkLoad/controller/Product/ProductController.java
@@ -3,8 +3,6 @@ package SilkLoad.controller.Product;
 
 import SilkLoad.SessionConst;
 import SilkLoad.dto.ProductFormDto;
-import SilkLoad.dto.ProductRecordDto;
-import SilkLoad.entity.Product;
 import SilkLoad.entity.ProductEnum.ProductTime;
 import SilkLoad.service.ProductService;
 import SilkLoad.entity.Members;
@@ -13,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +19,6 @@ import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.util.List;
 
 @Slf4j
 @Controller
@@ -49,6 +45,8 @@ public class ProductController {
         if (bindingResult.hasErrors()) {
             return "addProductForm";
         }
+
+
 
         HttpSession session = request.getSession();
         Members loginMember = (Members) session.getAttribute(SessionConst.LOGIN_MEMBER);

--- a/src/main/java/SilkLoad/dto/ProductFormDto.java
+++ b/src/main/java/SilkLoad/dto/ProductFormDto.java
@@ -1,7 +1,11 @@
 package SilkLoad.dto;
 
 
+import SilkLoad.entity.Category;
+import SilkLoad.entity.Members;
 import SilkLoad.entity.ProductEnum.ProductTime;
+import SilkLoad.entity.ProductEnum.ProductType;
+import lombok.Builder;
 import lombok.Data;
 import lombok.ToString;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,4 +37,18 @@ public class ProductFormDto {
     @NotNull
     private ProductTime productTime;
 
+    @Builder
+    public  ProductFormDto(String name,
+                        Long auctionPrice,
+                        Long instancePrice,
+                        String category,
+                        List<MultipartFile> imageFileList,
+                        String Explanation) {
+        this.name=name;
+        this.auctionPrice=auctionPrice;
+        this.instancePrice=instancePrice;
+        this.category=category;
+        this.imageFileList=imageFileList;
+        this.Explanation=Explanation;
+    }
 }

--- a/src/main/java/SilkLoad/entity/Product.java
+++ b/src/main/java/SilkLoad/entity/Product.java
@@ -83,8 +83,6 @@ public class Product {
         this.category = category;
         this.productTime = productTime;
         this.productImagesList = new ArrayList<>();
-
-
     }
 
 }

--- a/src/main/java/SilkLoad/service/ProductService.java
+++ b/src/main/java/SilkLoad/service/ProductService.java
@@ -60,8 +60,6 @@ public class ProductService {
             productImage.changeProduct(product);
             productImageRepository.save(productImage);
         });
-
-
     }
 
     private Product getProduct(ProductFormDto productFormDto, Members loginMember) {
@@ -77,6 +75,7 @@ public class ProductService {
                 .build();
         return product;
     }
+
 
     private Category categoryClassification(String categoryName) {
 
@@ -195,10 +194,11 @@ public class ProductService {
     }
 
     /**
-     * 매개변수 product를 통해 ProductSaleDto를 생성
+     * 매개변수 product를 통해 ProductRecordDto를 생성
      */
     public ProductRecordDto getProductRecordDto(Product product) {
-        ProductRecordDto productRecordDto = ProductRecordDto.builder().id(product.getId())
+        ProductRecordDto productRecordDto = ProductRecordDto.builder()
+                .id(product.getId())
                 .name(product.getName())
                 .auctionPrice(product.getAuctionPrice())
                 .instantPrice(product.getInstantPrice())
@@ -213,10 +213,10 @@ public class ProductService {
     }
 
     public List<ProductRecordDto> getProductRecordDtoList(List<Product> productList) {
-
         List<ProductRecordDto> productRecordDtoList = new ArrayList<>();
-        productList.forEach( (product -> {
-            ProductRecordDto productRecordDto = ProductRecordDto.builder().id(product.getId())
+        productList.forEach((product -> {
+            ProductRecordDto productRecordDto = ProductRecordDto.builder()
+                    .id(product.getId())
                     .name(product.getName())
                     .auctionPrice(product.getAuctionPrice())
                     .instantPrice(product.getInstantPrice())
@@ -228,7 +228,7 @@ public class ProductService {
                     .productImagesList(product.getProductImagesList())
                     .build();
             productRecordDtoList.add(productRecordDto);
-        }) );
+        }));
 
         return productRecordDtoList;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # mysql ?? (Data Source)
 spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
-spring.datasource.hikari.username=junho
+spring.datasource.hikari.username=root
 spring.datasource.hikari.password=1234
 
 # Resource and Thymeleaf Refresh
@@ -13,7 +13,7 @@ spring.servlet.session.tracking-modes=cookie
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=none
 
 # sql setting
 spring.jpa.open-in-view=false
@@ -27,9 +27,8 @@ spring.servlet.multipart.max-request-size=10MB
 
 # upload location
 
-imgFile.dir=C:/Users/0320k/my_coding/IdeaProjects/Spring/schoolProject/CD_Back/file/
-#E:/SilkLoad/file
-#imgFile.dir=E:/SilkLoad/file/
+#imgFile.dir=C:/Users/0320k/my_coding/IdeaProjects/Spring/schoolProject/CD_Back/file/
+imgFile.dir=E:/SilkLoad/file/
 
 # http request message check
 #logging.level.org.apache.coyote.http11=debug

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -75,11 +75,11 @@
 
 
                     <div class="navbar-tool dropdown ms-3">
-                        <a class="navbar-tool-icon-box bg-secondary dropdown-toggle" th:href="@{/MyPage}">
+                        <a class="navbar-tool-icon-box bg-secondary dropdown-toggle" th:href="@{/members/myPage/profile}">
                             <span class="navbar-tool-label">4</span>
                             <i class="navbar-tool-icon ci-cart"></i>
                         </a>
-                        <a class="navbar-tool-text" th:href="@{/MyPage}">
+                        <a class="navbar-tool-text" th:href="@{/members/myPage/profile}">
                             <small>My Page</small>
                             $265.00
                         </a>

--- a/src/test/java/SilkLoad/controller/Product/ProductControllerTest.java
+++ b/src/test/java/SilkLoad/controller/Product/ProductControllerTest.java
@@ -1,0 +1,7 @@
+package SilkLoad.controller.Product;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductControllerTest {
+
+}

--- a/src/test/java/SilkLoad/example/service/ProductAddTest.java
+++ b/src/test/java/SilkLoad/example/service/ProductAddTest.java
@@ -1,0 +1,75 @@
+package SilkLoad.example.service;
+
+
+import SilkLoad.dto.ProductFormDto;
+import SilkLoad.entity.Members;
+import SilkLoad.entity.Product;
+import SilkLoad.repository.MemberRepository;
+import SilkLoad.repository.ProductImageRepository;
+import SilkLoad.repository.ProductRepository;
+import SilkLoad.service.MemberService;
+import SilkLoad.service.ProductService;
+import org.apache.tomcat.util.http.fileupload.FileItem;
+import org.apache.tomcat.util.http.fileupload.IOUtils;
+import org.apache.tomcat.util.http.fileupload.disk.DiskFileItem;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.commons.CommonsMultipartFile;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.List;
+
+@SpringBootTest
+public class ProductAddTest {
+
+    @Autowired
+    ProductService productService;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    ProductImageRepository productImageRepository;
+
+    @Test
+    void 물품_DB에많이넣기_테스트() throws IOException {
+        Product product = productService.findById_Product((long) 314);
+
+
+        //더미 이미지 만들기, jpg -> MultipartFile로 만들기가 힘들다
+        List<MultipartFile> imageFiles = List.of(
+                new MockMultipartFile("7a88ca37-9e3b-4be3-af72-1bd6e5b7fe9f.jpg",
+                        "7a88ca37-9e3b-4be3-af72-1bd6e5b7fe9f.jpg",
+                        MediaType.IMAGE_JPEG_VALUE,
+                        "test1".getBytes())
+        );
+        
+        //새로운 물품 만들기
+        ProductFormDto test_product = ProductFormDto.builder()
+                .name(product.getName())
+                .instancePrice(product.getInstantPrice())
+                .auctionPrice(product.getAuctionPrice())
+                .Explanation(product.getExplanation())
+                .category("패딩점퍼,여성의류")
+                .imageFileList(imageFiles)
+                .build();
+
+        //DB에 있는 memeber 가지고 오기, member가 정해지지 않으면 영속성에서 외래키 오류가 발생한다
+        Members members = memberRepository.findById((long) 6).get();
+
+        productService.save(test_product, members);
+
+        productImageRepository.save(product.getProductImagesList().get(0));
+
+    }
+}

--- a/src/test/java/SilkLoad/example/service/ProductServiceTest.java
+++ b/src/test/java/SilkLoad/example/service/ProductServiceTest.java
@@ -3,8 +3,12 @@ package SilkLoad.example.service;
 import SilkLoad.dto.ProductRecordDto;
 import SilkLoad.entity.Product;
 import SilkLoad.entity.ProductEnum.ProductType;
+import SilkLoad.repository.ProductImageRepository;
+import SilkLoad.repository.ProductRepository;
 import SilkLoad.service.ProductService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -12,11 +16,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class ProductServiceTest {
 
     @Autowired
     ProductService productService;
 
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    ProductImageRepository productImageRepository;
 
     @Test
     void 물품_save_테스트(){
@@ -40,5 +50,34 @@ public class ProductServiceTest {
         for (ProductRecordDto product : allProduct) {
             System.out.println("product = " + product.getProductImagesList().get(0).getStoreFileName());
         }
+    }
+
+    @Test
+    void 물품_DB에많이넣기_테스트(){
+        Product byId_product = productService.findById_Product((long) 1);
+//        ProductRecordDto productRecordDto = productService.getProductRecordDto(byId_product);
+
+//        ProductFormDtoTest test_product = ProductFormDtoTest.builder()
+//                .name(byId_product.getName())
+//                .instancePrice(byId_product.getInstantPrice())
+//                .auctionPrice(byId_product.getAuctionPrice())
+//                .Explanation(byId_product.getExplanation())
+//                .category("패딩점퍼,여성의류")
+//                .imageFileList(productRecordDto.getProductImagesList())
+//                .build();
+//
+//        Members test_member = Members.builder()
+//                .name(byId_product.getMembers().getName())
+//                .loginId(byId_product.getMembers().getLoginId())
+//                .password(byId_product.getMembers().getPassword())
+//                .numberPurchase(byId_product.getMembers().getNumberPurchase())
+//                .ranks(byId_product.getMembers().getRanks())
+//                .build();
+
+//        byId_product.changeCategory(productService.categoryClassification("패딩점퍼,여성의류"));
+        productRepository.save(byId_product);
+        productImageRepository.save(byId_product.getProductImagesList().get(0));
+
+        System.out.println("저장됨");
     }
 }

--- a/src/test/java/SilkLoad/repository/ProductImageRepositoryTest.java
+++ b/src/test/java/SilkLoad/repository/ProductImageRepositoryTest.java
@@ -1,7 +1,0 @@
-package SilkLoad.repository;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class ProductImageRepositoryTest {
-
-}


### PR DESCRIPTION
## ✏Change Details

- ProductAddTest 추가 (아래설명)
- header에 mypage로 가는 url을 members/mypage/profile로 변경

## 💬Comment

- 페이지를 나눠서 물품을 보여줄 때 **DB에 넣어야할 물품을 하드코딩해서 넣기 쉽게**하려고
- 화면에서 넘어오는 객체(form)을 그냥 builer로 생성해봄

## 📑References

- 

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?