### PR TITLE
카테고리 기준으로 크롤링 데이터  shop페이지에 물품 보여주기

### DIFF
--- a/crawling/crawling_bunjang.py
+++ b/crawling/crawling_bunjang.py
@@ -1,15 +1,15 @@
-from asyncio import threads
+# from multiprocessing import Pool
+import threading
 import time
+
 import pymysql
+from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
-from bs4 import BeautifulSoup
-import schedule
-# from multiprocessing import Pool
-import threading
 
-category_list = [[["310090050", "310090060", "310090999", "310110030", "310110010", "310240", "310230", "310260200", "310260100", "310260300",
+category_list = [
+                    [["310090050", "310090060", "310090999", "310110030", "310110010", "310240", "310230", "310260200", "310260100", "310260300",
                    "310040090", "310040080", "310040070", "310040999", "310050010", "310050050", "310050030", "310050040", "310050999", "310150030",
                    "310150010", "310150040", "310150070", "310150999", "310140020", "310140010", "310140030", "310140040", "310140999", "310160010",
                    "310160060", "310160020", "310160999", "310130030", "310130080", "310130040", "310120030", "310120110", "310120020", "310070",
@@ -91,7 +91,8 @@ category_list = [[["310090050", "310090060", "310090999", "310110030", "31011001
                    "500120006", "500120005", "500120007",  # 유아동/출산 500 하위 카테고리 73개"""
 
                    "980100", "980200", "980400", "980500", "980990",  # 반려동물용품 980 하위 카테고리 5개"""
-                   ]]]  # 기타 999"""
+                   ]]
+                 ]  # 기타 999"""
 
 
 def crawling(category_list):
@@ -158,7 +159,7 @@ def crawling(category_list):
             i += 1
 
     connect = pymysql.connect(
-        host='localhost', user='root', password='root', db='silkLoad', charset='utf8mb4')
+        host='localhost', user='root', password='1234', db='silkLoad', charset='utf8mb4')
     cursor = connect.cursor()
 
     # delete = """delete from crawling where exists(select * from crawling)"""
@@ -188,10 +189,10 @@ def crawling(category_list):
 
 def db_reset():
     connect = pymysql.connect(
-        host='localhost', user='root', password='root', db='silkLoad', charset='utf8mb4')
+        host='localhost', user='root', password='1234', db='silkload', charset='utf8mb4')
     cursor = connect.cursor()
 
-    delete = """delete from crawling where exists(select * from crawling)"""
+    delete = """delete from crawling"""
     cursor.execute(delete)
 
     alter = """alter table crawling auto_increment=1"""

--- a/src/main/java/SilkLoad/controller/Home/HomeController.java
+++ b/src/main/java/SilkLoad/controller/Home/HomeController.java
@@ -39,26 +39,26 @@ public class HomeController {
     @GetMapping("/")
     public String home(Model model,
                        HttpServletRequest request,
-                       @PageableDefault(size=8) Pageable pageable) {//@PageableDefault로 기본 8개를 가지고 오게했다.
+                       @PageableDefault(size=8) Pageable pageable) {//@PageableDefault로 기본 8개를 가지고 오게했다crawling.
         List<ProductRecordDto> content = productService.paged_product(pageable).getContent();
 
         model.addAttribute("Products", content);
         model.addAttribute("sale", ProductType.sale);
 
-        Page<CrawlingDto> women_close = crawlingService.getcrawlingdata(pageable, "여성의류");
-        Page<CrawlingDto> men_close = crawlingService.getcrawlingdata(pageable,"남성의류");
-        Page<CrawlingDto> shose = crawlingService.getcrawlingdata(pageable, "패션");
-        Page<CrawlingDto> sport = crawlingService.getcrawlingdata(pageable, "스포츠");
-        Page<CrawlingDto> car = crawlingService.getcrawlingdata(pageable, "차량");
-        Page<CrawlingDto> star = crawlingService.getcrawlingdata(pageable, "굿즈");
-        Page<CrawlingDto> toy = crawlingService.getcrawlingdata(pageable, "키덜트");
-        Page<CrawlingDto> art = crawlingService.getcrawlingdata(pageable, "예술");
-        Page<CrawlingDto> book = crawlingService.getcrawlingdata(pageable, "도서");
-        Page<CrawlingDto> family = crawlingService.getcrawlingdata(pageable, "가구");
-        Page<CrawlingDto> life = crawlingService.getcrawlingdata(pageable, "생활");
-        Page<CrawlingDto> kid = crawlingService.getcrawlingdata(pageable, "유아");
-        Page<CrawlingDto> animal = crawlingService.getcrawlingdata(pageable, "동물");
-        Page<CrawlingDto> etc = crawlingService.getcrawlingdata(pageable, "기타");
+        Page<CrawlingDto> women_close = crawlingService.getcrawlingdatafirst(pageable, "여성의류");
+        Page<CrawlingDto> men_close = crawlingService.getcrawlingdatafirst(pageable,"남성의류");
+        Page<CrawlingDto> shose = crawlingService.getcrawlingdatafirst(pageable, "신발");
+        Page<CrawlingDto> sport = crawlingService.getcrawlingdatafirst(pageable, "스포츠/레저");
+        Page<CrawlingDto> car = crawlingService.getcrawlingdatafirst(pageable, "차량/오토바이");
+        Page<CrawlingDto> star = crawlingService.getcrawlingdatafirst(pageable, "스타굿즈");
+        Page<CrawlingDto> toy = crawlingService.getcrawlingdatafirst(pageable, "키덜트");
+        Page<CrawlingDto> art = crawlingService.getcrawlingdatafirst(pageable, "예술/희귀/수집품");
+        Page<CrawlingDto> book = crawlingService.getcrawlingdatafirst(pageable, "도서/티켓/문구");
+        Page<CrawlingDto> family = crawlingService.getcrawlingdatafirst(pageable, "가구/인테리어");
+        Page<CrawlingDto> life = crawlingService.getcrawlingdatafirst(pageable, "생활/가공식품");
+        Page<CrawlingDto> kid = crawlingService.getcrawlingdatafirst(pageable, "유아동/출산");
+        Page<CrawlingDto> animal = crawlingService.getcrawlingdatafirst(pageable, "반려동물용품");
+        Page<CrawlingDto> etc = crawlingService.getcrawlingdatafirst(pageable, "기타");
 
         model.addAttribute("women_close",women_close);
         model.addAttribute("men_close",men_close);

--- a/src/main/java/SilkLoad/controller/Shop/ShopController.java
+++ b/src/main/java/SilkLoad/controller/Shop/ShopController.java
@@ -89,7 +89,7 @@ public class ShopController {
                                 @PageableDefault(size = 9) Pageable pageable,
                                 Model model) {
 
-        List<ProductRecordDto> allProduct = productService.findAllProduct();
+//        List<ProductRecordDto> allProduct = productService.findAllProduct();
 
         ProductRecordDto byId_productRecordDto = productService.findById_ProductRecordDto(id);
 
@@ -101,13 +101,14 @@ public class ShopController {
         }
 
         //--------------------크롤링 데이터 보내는 부분----------------------
-        Page<CrawlingDto> crawlingdata = crawlingService.getcrawlingdatafirst(pageable, first);
+        Page<CrawlingDto> crawlingdata = crawlingService.getcrawlingdatathird(pageable, third);
         model.addAttribute("crawlingdata",crawlingdata);
+        //----------------------------------------------------------------
 
         model.addAttribute("maxAuctionPrice", maxAuctionPrice);
         model.addAttribute("productTime", ProductTime.values());
         model.addAttribute("product", byId_productRecordDto);
-        model.addAttribute("allProduct", allProduct);
+//        model.addAttribute("allProduct", allProduct);
 
         return "detailProduct";
     }

--- a/src/main/java/SilkLoad/controller/Shop/ShopController.java
+++ b/src/main/java/SilkLoad/controller/Shop/ShopController.java
@@ -31,13 +31,13 @@ public class ShopController {
 
     @GetMapping
     public String shop(Model model,
-                       @RequestParam(required = false, name = "category") String category,
                        @RequestParam(required = false, name = "first") String first,
+                       @RequestParam(required = false, name = "second") String second,
                        @RequestParam(required = false, name = "keyword")String keyword,
                        @PageableDefault(size = 9) Pageable pageable) {
         //카테고리들
-        model.addAttribute("category", category);
-        model.addAttribute("first",first);
+        model.addAttribute("first", first);
+        model.addAttribute("second",second);
 
 
         //전체 페이지 수
@@ -45,18 +45,16 @@ public class ShopController {
         //현제 페이지
         int presentPage = productService.paged_product(pageable).getNumber();
 
-        log.info("keyword입니다. = {}",keyword);
 
         List<ProductRecordDto> content;
         //first가 있는지 없는지에 따라 content가 변한다.
-        if(first != null)
-            content = productService.pagedByfirstcategoryProduct(first, pageable).getContent();
+        if(second != null)
+            content = productService.pagedBysecondcategoryProduct(second, pageable).getContent();
         else if(keyword != null)
             content = productService.SearchToProductname(keyword, pageable).getContent();
         else
             //페이징화 된 객체
-            content = productService.pagedBysecondcategoryProduct(category, pageable).getContent();
-
+            content = productService.pagedByfirstcategoryProduct(first, pageable).getContent();
 
         model.addAttribute("allProduct", content);
         //전체 페이지 수 모델로 보내기
@@ -68,7 +66,9 @@ public class ShopController {
 
 
         //--------------------크롤링 데이터 보내는 부분----------------------
-        Page<CrawlingDto> crawlingdata = crawlingService.getcrawlingdata(pageable, category);
+        String crawlingcategory;
+        crawlingcategory = second;
+        Page<CrawlingDto> crawlingdata = crawlingService.getcrawlingdatasecond(pageable, crawlingcategory);
         model.addAttribute("crawlingdata",crawlingdata);
 
         return "shop";
@@ -83,8 +83,9 @@ public class ShopController {
      */
     @GetMapping("/detailProduct")
     public String detailProduct(@RequestParam Long id,
-                                @RequestParam(required = false, name = "category") String category,
                                 @RequestParam(required = false, name = "first") String first,
+                                @RequestParam(required = false, name = "second") String second,
+                                @RequestParam(required = false, name = "third") String third,
                                 @PageableDefault(size = 9) Pageable pageable,
                                 Model model) {
 
@@ -100,7 +101,7 @@ public class ShopController {
         }
 
         //--------------------크롤링 데이터 보내는 부분----------------------
-        Page<CrawlingDto> crawlingdata = crawlingService.getcrawlingdata(pageable, category);
+        Page<CrawlingDto> crawlingdata = crawlingService.getcrawlingdatafirst(pageable, first);
         model.addAttribute("crawlingdata",crawlingdata);
 
         model.addAttribute("maxAuctionPrice", maxAuctionPrice);

--- a/src/main/java/SilkLoad/dto/CategoryRecordDto.java
+++ b/src/main/java/SilkLoad/dto/CategoryRecordDto.java
@@ -9,4 +9,5 @@ public class CategoryRecordDto {
 
     private String first;
     private String second;
+    private String third;
 }

--- a/src/main/java/SilkLoad/dto/ProductCategoryDto.java
+++ b/src/main/java/SilkLoad/dto/ProductCategoryDto.java
@@ -25,6 +25,7 @@ public class ProductCategoryDto {
     private ProductType productType;
     private String first;
     private String second;
+    private String third;
     private String uploadFileName;  //회원이 올린 파일 이름
     private String storeFileName;   //실제 저장 될 파일 이름
 
@@ -38,6 +39,7 @@ public class ProductCategoryDto {
                               ProductType productType,
                               String first,
                               String second,
+                              String third,
                               String uploadFileName,
                               String storeFileName) {
         this.id = id;
@@ -50,6 +52,7 @@ public class ProductCategoryDto {
         this.productType = productType;
         this.first = first;
         this.second = second;
+        this.third = third;
         this.uploadFileName = uploadFileName;
         this.storeFileName = storeFileName;
     }

--- a/src/main/java/SilkLoad/entity/Crawling.java
+++ b/src/main/java/SilkLoad/entity/Crawling.java
@@ -18,7 +18,10 @@ public class Crawling {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // PK
 
-    private String category;
+    private String site_name;
+    private String first;
+    private String second;
+    private String third;
     private String name;
     private String price;
     private String link;

--- a/src/main/java/SilkLoad/interceptor/ErrorPageCheckInterceptor.java
+++ b/src/main/java/SilkLoad/interceptor/ErrorPageCheckInterceptor.java
@@ -1,0 +1,27 @@
+package SilkLoad.interceptor;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ErrorPageCheckInterceptor implements HandlerInterceptor {
+
+    //에러 페이지로 보내기
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        response.sendError(404);
+        return false;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/src/main/java/SilkLoad/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/SilkLoad/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,55 @@
+package SilkLoad.interceptor;
+
+import SilkLoad.SessionConst;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@Slf4j
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    /**
+     * 인터셉터 처리 첫 부분
+     * 컨트롤러에 요청이 가기전에 실행되는 메소드
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String requestURI = request.getRequestURI();
+
+        log.info("인증 체크 인터셉터 실행 {}", requestURI);
+        HttpSession session = request.getSession(false);
+
+        if (session == null || session.getAttribute(SessionConst.LOGIN_MEMBER) == null ) {
+            log.info("미인증 사용자 요청");
+
+            response.sendRedirect("/login?redirectURL=" + requestURI);
+            //컨트롤러에 요청 x
+            return false;
+        }
+        //컨트롤러 요청 O
+        return true;
+
+    }
+
+    /**
+     * preHandle을 통과하고 controller를 거친 후에 실행되는 메소드
+     */
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+
+    /**
+     * preHandle에서 오류가 나던 안 나던 무조건 실행되는 부분
+     * preHandle 실행 후에 실행되는 부분
+     */
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/src/main/java/SilkLoad/repository/CategoryRepository.java
+++ b/src/main/java/SilkLoad/repository/CategoryRepository.java
@@ -15,5 +15,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     //1차,2차,3차 카테고리를 받아서 Category엔티티를 반환한다.
     //거기에는 productList가 들어있다.
     @EntityGraph("CategoryWithProduct")
+    Optional<Category> findTopByFirstAndSecondAndThird(String first, String second, String third);
+    @EntityGraph("CategoryWithProduct")
     Optional<Category> findByFirstAndSecondAndThird(String first, String second, String third);
 }

--- a/src/main/java/SilkLoad/repository/CrawlingRepository.java
+++ b/src/main/java/SilkLoad/repository/CrawlingRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.domain.Pageable;
 @Repository
 public interface CrawlingRepository extends JpaRepository<Crawling, Long> {
 
-    Page<Crawling> findByCategory(String category, Pageable pageable);
-
-
+    Page<Crawling> findByFirst(String first, Pageable pageable);
+    Page<Crawling> findBySecond(String second, Pageable pageable);
+    Page<Crawling> findByThird(String third, Pageable pageable);
 
 }

--- a/src/main/java/SilkLoad/repository/ProductRepository.java
+++ b/src/main/java/SilkLoad/repository/ProductRepository.java
@@ -27,7 +27,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     //Product 안에 원하는 category(second) 빼오는 쿼리
     @Query(value = "SELECT " +
             "new SilkLoad.dto.ProductCategoryDto(p.id, p.name, p.auctionPrice, p.instantPrice, p.explanation, " +
-            "p.createdDate, p.productTime ,p.productType, p.category.first, p.category.second, img.uploadFileName, img.storeFileName) " +
+            "p.createdDate, p.productTime ,p.productType, p.category.first, p.category.second, p.category.third, img.uploadFileName, img.storeFileName) " +
             "from Product p " +
             "left join ProductImage img " +
             "on p.id = img.product.id " +
@@ -39,7 +39,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     //Product 안에 원하는 category(second) 빼오는 쿼리
     @Query(value = "SELECT " +
             "new SilkLoad.dto.ProductCategoryDto(p.id, p.name, p.auctionPrice, p.instantPrice, p.explanation, " +
-            "p.createdDate, p.productTime ,p.productType, p.category.first, p.category.second, img.uploadFileName, img.storeFileName) " +
+            "p.createdDate, p.productTime ,p.productType, p.category.first, p.category.second, p.category.third, img.uploadFileName, img.storeFileName) " +
             "from Product p " +
             "left join ProductImage img " +
             "on p.id = img.product.id " +
@@ -47,6 +47,17 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "AND p.productType = SilkLoad.entity.ProductEnum.ProductType.sale "
     )
     Page<ProductCategoryDto> findfirstcategory(@Param("first")String categoryName, Pageable pageable);
+
+    @Query(value = "SELECT " +
+            "new SilkLoad.dto.ProductCategoryDto(p.id, p.name, p.auctionPrice, p.instantPrice, p.explanation, " +
+            "p.createdDate, p.productTime ,p.productType, p.category.first, p.category.second, p.category.third, img.uploadFileName, img.storeFileName) " +
+            "from Product p " +
+            "left join ProductImage img " +
+            "on p.id = img.product.id " +
+            "where p.category.third = :third " +
+            "AND p.productType = SilkLoad.entity.ProductEnum.ProductType.sale "
+    )
+    Page<ProductCategoryDto> findthirdcategory(@Param("third")String categoryName, Pageable pageable);
 
     //검색해서 Product를 반환하는 쿼리
 

--- a/src/main/java/SilkLoad/service/CrawlingService.java
+++ b/src/main/java/SilkLoad/service/CrawlingService.java
@@ -26,7 +26,7 @@ public class CrawlingService {
      * @param crawling
      * @return
      */
-    public CrawlingDto getCrawlingDtoList(Crawling crawling){
+    public CrawlingDto ToCrawlingDto(Crawling crawling){
 
         CrawlingDto crawlingDto = CrawlingDto.builder()
                 .name(crawling.getName())
@@ -39,28 +39,31 @@ public class CrawlingService {
         return crawlingDto;
     }
 
-    /**
-     * 크롤링 데이터를 카태고리 별로 가지고 온다.
-     * @param pageable
-     * @param first
-     * @return
-     */
+    //crawling 데이터를 first 기준으로 데이터 리턴
     @Transactional(readOnly = true)
     public Page<CrawlingDto> getcrawlingdatafirst(Pageable pageable, String first) {
 
         Page<CrawlingDto> data = crawlingRepository
                                     .findByFirst(first, pageable)
-                                    .map(this::getCrawlingDtoList);
-        log.info("first 쪽 data가 잘 들어오는지 ={}",data);
+                                    .map(this::ToCrawlingDto);
         return data;
     }
+
+    //crawling 데이터를 second 기준으로 데이터 리턴
     @Transactional(readOnly = true)
     public Page<CrawlingDto> getcrawlingdatasecond(Pageable pageable, String second) {
         Page<CrawlingDto> data = crawlingRepository
                 .findBySecond(second, pageable)
-                .map(this::getCrawlingDtoList);
-        log.info("second 쪽 data가 잘 들어오는지 ={}",data);
+                .map(this::ToCrawlingDto);
         return data;
     }
 
+    //crawling 데이터를 third기준으로 데이터 리턴
+    @Transactional(readOnly = true)
+    public Page<CrawlingDto> getcrawlingdatathird(Pageable pageable, String third) {
+        Page<CrawlingDto> data = crawlingRepository
+                .findByThird(third, pageable)
+                .map(this::ToCrawlingDto);
+        return data;
+    }
 }

--- a/src/main/java/SilkLoad/service/CrawlingService.java
+++ b/src/main/java/SilkLoad/service/CrawlingService.java
@@ -30,7 +30,7 @@ public class CrawlingService {
 
         CrawlingDto crawlingDto = CrawlingDto.builder()
                 .name(crawling.getName())
-                .category(crawling.getCategory())
+                .category(crawling.getFirst())
                 .img_link(crawling.getImg_link())
                 .link(crawling.getLink())
                 .price(crawling.getPrice())
@@ -42,17 +42,25 @@ public class CrawlingService {
     /**
      * 크롤링 데이터를 카태고리 별로 가지고 온다.
      * @param pageable
-     * @param category
+     * @param first
      * @return
      */
     @Transactional(readOnly = true)
-    public Page<CrawlingDto> getcrawlingdata(Pageable pageable, String category) {
+    public Page<CrawlingDto> getcrawlingdatafirst(Pageable pageable, String first) {
 
         Page<CrawlingDto> data = crawlingRepository
-                                    .findByCategory(category, pageable)
+                                    .findByFirst(first, pageable)
                                     .map(this::getCrawlingDtoList);
+        log.info("first 쪽 data가 잘 들어오는지 ={}",data);
         return data;
     }
-
+    @Transactional(readOnly = true)
+    public Page<CrawlingDto> getcrawlingdatasecond(Pageable pageable, String second) {
+        Page<CrawlingDto> data = crawlingRepository
+                .findBySecond(second, pageable)
+                .map(this::getCrawlingDtoList);
+        log.info("second 쪽 data가 잘 들어오는지 ={}",data);
+        return data;
+    }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.servlet.session.tracking-modes=cookie
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=update
 
 # sql setting
 spring.jpa.open-in-view=false
@@ -27,8 +27,8 @@ spring.servlet.multipart.max-request-size=10MB
 
 # upload location
 
-imgFile.dir=C:/Users/0320k/my_coding/IdeaProjects/Spring/schoolProject/CD_Back/file/
-#imgFile.dir=E:/SilkLoad/file/
+#imgFile.dir=C:/Users/0320k/my_coding/IdeaProjects/Spring/schoolProject/CD_Back/file/
+imgFile.dir=E:/SilkLoad/file/
 
 # http request message check
 #logging.level.org.apache.coyote.http11=debug

--- a/src/main/resources/templates/detailProduct.html
+++ b/src/main/resources/templates/detailProduct.html
@@ -392,18 +392,18 @@
 
                             <!--가격-->
                             <div class="mb-3"><span class="h3 fw-normal text-accent me-1"
-                                                    th:text="${product.instantPrice}"><small>원</small></span>
-                                <del class="fs-lg me-3">원</del>
+                                                    th:text="${product.instantPrice}"></span>
+                                <span class="me-3">원</span>
                             </div>
 
                             <div class="fs-sm mb-4">
                                 <span class="text-heading fw-medium me-1">카테고리:</span>
                                 <span class="text-muted" id="colorOption1"
-                                      th:utext="${product.categoryRecordDto.getFirst()()}"></span>
+                                      th:utext="${product.categoryRecordDto.getFirst()}"></span>
                                 <span class="text-muted" id="colorOption2"
                                       th:text="${product.categoryRecordDto.getSecond()}"></span>
-                                <span class="text-muted" id="colorOption3"
-                                      th:text="${product.categoryRecordDto.getThird()}"></span>
+<!--                                <span class="text-muted" id="colorOption3"-->
+<!--                                      th:text="${product.categoryRecordDto.getThird()}"></span>-->
                             </div>
 
 
@@ -516,7 +516,6 @@
                                 <div class="d-flex justify-content-between">
                                     <div class="product-price">
                                     <span class="text-accent" th:text="|${product.getPrice()} 원|">
-                                      <small></small>
                                     </span>
                                 </div>
 

--- a/src/main/resources/templates/detailProduct.html
+++ b/src/main/resources/templates/detailProduct.html
@@ -399,9 +399,11 @@
                             <div class="fs-sm mb-4">
                                 <span class="text-heading fw-medium me-1">카테고리:</span>
                                 <span class="text-muted" id="colorOption1"
-                                      th:utext="${product.categoryRecordDto.getSecond()}"></span>
+                                      th:utext="${product.categoryRecordDto.getFirst()()}"></span>
                                 <span class="text-muted" id="colorOption2"
-                                      th:text="${product.categoryRecordDto.getFirst()}"></span>
+                                      th:text="${product.categoryRecordDto.getSecond()}"></span>
+                                <span class="text-muted" id="colorOption3"
+                                      th:text="${product.categoryRecordDto.getThird()}"></span>
                             </div>
 
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -28,7 +28,7 @@
 
                 <div class="card product-card" th:if="${product.getProductType == sale}" >
 
-                    <a class="card-img-top d-block overflow-hidden" th:href="@{/shop/detailProduct(id=${product.id}, category=${product.categoryRecordDto.getSecond()}, first=${product.categoryRecordDto.getFirst()})}">
+                    <a class="card-img-top d-block overflow-hidden" th:href="@{/shop/detailProduct(id=${product.id}, first=${product.categoryRecordDto.getFirst()}, second=${product.categoryRecordDto.getSecond()} , third=${product.categoryRecordDto.getThird()} )}">
                         <figure class="image is-4by3">
                             <img alt="Product"  th:src="|/product/images/${product.productImagesList.get(0).getStoreFileName()}|"/>
                         </figure>
@@ -36,7 +36,7 @@
                     <div class="card-body py-2"><a class="product-meta d-block fs-xs pb-1" href="#" th:text="${product.categoryRecordDto.getSecond()}">카테고리</a>
 
                         <h3 class="product-title fs-sm" >
-                            <a th:href="@{/shop/detailProduct(id=${product.id}, category=${product.categoryRecordDto.getSecond()}, first=${product.categoryRecordDto.getFirst()})}" th:text="${product.getName()}">물품제목</a>
+                            <a th:href="@{/shop/detailProduct(id=${product.id}, first=${product.categoryRecordDto.getFirst()}, second=${product.categoryRecordDto.getSecond()} , third=${product.categoryRecordDto.getThird()} )}" th:text="${product.getName()}">물품제목</a>
                         </h3>
                         <div>
                             <div class="product-price col"><span class="text-accent" th:text="|즉시 구매가: ${product.instantPrice} 원 |"></span></div>

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -112,7 +112,7 @@
                         </a>
                         <a class="nav-link dropdown-toggle" th:classappend="${paramActive == 'shop'} ? active"
                            type="button"
-                           th:onclick="|location.href='@{/shop/(category=여성의류,first=패딩점퍼)}'|">
+                           th:onclick="|location.href='@{/shop/(first=여성의류,second=맨투맨)}'|">
                             Shop
                         </a>
                         <a class="nav-link dropdown-toggle" th:classappend="${paramActive == 'selling'} ? active"

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -65,7 +65,7 @@
                     <div class="col-md-4 col-sm-6 px-2 mb-4" th:each="product : ${allProduct}">
                         <div class="card product-card" th:if="${product.getProductType == sale}" >
                             <a class="card-img-top d-block overflow-hidden"
-                               th:href="@{/shop/detailProduct(id=${product.id}, category=${product.categoryRecordDto.getSecond()}, first=${product.categoryRecordDto.getFirst()})}">
+                               th:href="@{/shop/detailProduct(id=${product.id}, first=${product.categoryRecordDto.getFirst()}, second=${product.categoryRecordDto.getSecond()}, third=${product.categoryRecordDto.getThird()} )}">
                                 <img alt="Product"  th:src="|/product/images/${product.productImagesList.get(0).getStoreFileName()}|"/>
                             </a>
                             <div class="card-body py-2">

--- a/src/main/resources/templates/shopSidebar.html
+++ b/src/main/resources/templates/shopSidebar.html
@@ -30,85 +30,85 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='패딩점퍼')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='패딩/점퍼')}"  href="#">
                                                 <span class="widget-filter-item-text">패딩점퍼</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='맨투맨')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='맨투맨')}"  href="#">
                                                 <span class="widget-filter-item-text">맨투맨</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='코드')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='코트')}"  href="#">
                                                 <span class="widget-filter-item-text">코드</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='후드티')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='후드티/후드집업')}"  href="#">
                                                 <span class="widget-filter-item-text">후드티</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='티셔츠')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='티셔츠')}"  href="#">
                                                 <span class="widget-filter-item-text">티셔츠</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='셔츠')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='셔츠')}"  href="#">
                                                 <span class="widget-filter-item-text">셔츠</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='바지')}" href="#">
+                                               th:href="@{/shop/(first='여성의류', second='바지')}" href="#">
                                                 <span class="widget-filter-item-text">바지</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='반바지')}" href="#">
+                                               th:href="@{/shop/(first='여성의류', second='반바지')}" href="#">
                                                 <span class="widget-filter-item-text">반바지</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='정장')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='정장')}"  href="#">
                                                 <span class="widget-filter-item-text">정장</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='트레이닝')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='트레이닝')}"  href="#">
                                                 <span class="widget-filter-item-text">트레이닝</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='언더웨어홈웨어')}"  href="#">
-                                                <span class="widget-filter-item-text">언더웨어홈웨어</span>
+                                               th:href="@{/shop/(first='여성의류', second='언더웨어/홈웨어')}"  href="#">
+                                                <span class="widget-filter-item-text">언더웨어/홈웨어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='치마')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='치마')}"  href="#">
                                                 <span class="widget-filter-item-text">치마</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='원피스')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='원피스')}"  href="#">
                                                 <span class="widget-filter-item-text">원피스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='여성의류', first='가디건')}"  href="#">
+                                               th:href="@{/shop/(first='여성의류', second='가디건')}"  href="#">
                                                 <span class="widget-filter-item-text">가디건</span>
                                             </a>
                                         </li>
@@ -131,73 +131,73 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='패딩점퍼')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='패딩/점퍼')}"  href="#">
                                                 <span class="widget-filter-item-text">패딩점퍼</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='맨투맨')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='맨투맨')}"  href="#">
                                                 <span class="widget-filter-item-text">맨투맨</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='코드')}"  href="#">
-                                                <span class="widget-filter-item-text">코드</span>
+                                               th:href="@{/shop/(first='남성의류', second='코트')}"  href="#">
+                                                <span class="widget-filter-item-text">코트</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='후드티후드집업')}"  href="#">
-                                                <span class="widget-filter-item-text">후드티후드집업</span>
+                                               th:href="@{/shop/(first='남성의류', second='후드티/후드집업')}"  href="#">
+                                                <span class="widget-filter-item-text">후드티/후드집업</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='티셔츠')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='티셔츠')}"  href="#">
                                                 <span class="widget-filter-item-text">티셔츠</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='셔츠')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='셔츠')}"  href="#">
                                                 <span class="widget-filter-item-text">셔츠</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='바지')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='바지')}"  href="#">
                                                 <span class="widget-filter-item-text">바지</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='반바지')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='반바지')}"  href="#">
                                                 <span class="widget-filter-item-text">반바지</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='정장')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='정장')}"  href="#">
                                                 <span class="widget-filter-item-text">정장</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='트레이닝')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='트레이닝')}"  href="#">
                                                 <span class="widget-filter-item-text">트레이닝</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='언더웨어홈웨어')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='언더웨어/홈웨어')}"  href="#">
                                                 <span class="widget-filter-item-text">언더웨어홈웨어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='남성의류', first='가디건')}"  href="#">
+                                               th:href="@{/shop/(first='남성의류', second='가디건')}"  href="#">
                                                 <span class="widget-filter-item-text">가디건</span>
                                             </a>
                                         </li>
@@ -220,19 +220,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='신발', first='가디건')}" href="#">
+                                               th:href="@{/shop/(first='신발', second='가디건')}" href="#">
                                                 <span class="widget-filter-item-text">스니커즈</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='신발', first='남성화')}" href="#">
+                                               th:href="@{/shop/(first='신발', second='남성화')}" href="#">
                                                 <span class="widget-filter-item-text">남성화</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='신발', first='여성화')}" href="#">
+                                               th:href="@{/shop/(first='신발', second='여성화')}" href="#">
                                                 <span class="widget-filter-item-text">여성화</span>
                                             </a>
                                         </li>
@@ -256,19 +256,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='가방', first='여성가방')}" href="#">
+                                               th:href="@{/shop/(first='가방', second='여성가방')}" href="#">
                                                 <span class="widget-filter-item-text">여성가방</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='가방', first='남성가방')}" href="#">
+                                               th:href="@{/shop/(first='가방', second='남성가방')}" href="#">
                                                 <span class="widget-filter-item-text">남성가방</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='가방', first='여행용')}" href="#">
+                                               th:href="@{/shop/(first='가방', second='여행용')}" href="#">
                                                 <span class="widget-filter-item-text">여행용</span>
                                             </a>
                                         </li>
@@ -291,13 +291,13 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='시계', first='시계')}" href="#">
+                                               th:href="@{/shop/(first='시계', second='시계')}" href="#">
                                                 <span class="widget-filter-item-text">시계</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='시계', first='쥬얼리')}" href="#">
+                                               th:href="@{/shop/(first='시계', second='쥬얼리')}" href="#">
                                                 <span class="widget-filter-item-text">쥬얼리</span>
                                             </a>
                                         </li>
@@ -320,50 +320,50 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='지갑')}" href="#">
+                                               th:href="@{/shop/(first='패션', second='지갑')}" href="#">
                                                 <span class="widget-filter-item-text">지갑</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='벨트')}" href="#">
+                                               th:href="@{/shop/(first='패션', second='벨트')}" href="#">
                                                 <span class="widget-filter-item-text">벨트</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='모자')}" href="#">
+                                               th:href="@{/shop/(first='패션', second='모자')}" href="#">
                                                 <span class="widget-filter-item-text">모자</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='스카프넥타이')}" href="#">
-                                                <span class="widget-filter-item-text">스카프넥타이</span>
+                                               th:href="@{/shop/(first='패션', second='스카프/넥타이')}" href="#">
+                                                <span class="widget-filter-item-text">스카프/넥타이</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='안경선글라스')}" href="#">
-                                                <span class="widget-filter-item-text">안경선글라스</span>
+                                               th:href="@{/shop/(first='패션', second='안경/선글라스')}" href="#">
+                                                <span class="widget-filter-item-text">안경/선글라스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='양말스타킹')}" href="#">
-                                                <span class="widget-filter-item-text">양말스타킹</span>
+                                               th:href="@{/shop/(first='패션', second='양말/스타킹')}" href="#">
+                                                <span class="widget-filter-item-text">양말/스타킹</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='우산양산')}" href="#">
-                                                <span class="widget-filter-item-text">우산양산</span>
+                                               th:href="@{/shop/(first='패션', second='우산/양산')}" href="#">
+                                                <span class="widget-filter-item-text">우산/양산</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='패션', first='기타')}" href="#">
-                                                <span class="widget-filter-item-text">기타 악세서리</span>
+                                               th:href="@{/shop/(first='패션', second='기타 액세서리')}" href="#">
+                                                <span class="widget-filter-item-text">기타/악세서리</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -385,44 +385,44 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='모바일')}" href="#">
+                                               th:href="@{/shop/(first='디지털', second='모바일')}" href="#">
                                                 <span class="widget-filter-item-text">모바일</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='가전제품')}" href="#">
+                                               th:href="@{/shop/(first='디지털', second='가전제품')}" href="#">
                                                 <span class="widget-filter-item-text">가전제품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='오디오영상관련기기')}" href="#">
-                                                <span class="widget-filter-item-text">오디오영상관련기기</span>
+                                               th:href="@{/shop/(first='디지털', second='오디오/영상/관련기기')}" href="#">
+                                                <span class="widget-filter-item-text">오디오/영상/관련기기</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='PC노트북')}" href="#">
-                                                <span class="widget-filter-item-text">PC노트북</span>
+                                               th:href="@{/shop/(first='디지털', second='PC/노트북')}" href="#">
+                                                <span class="widget-filter-item-text">PC/노트북</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='게임타이틀')}" href="#">
-                                                <span class="widget-filter-item-text">게임타이틀</span>
+                                               th:href="@{/shop/(first='디지털', second='게임/타이틀')}" href="#">
+                                                <span class="widget-filter-item-text">게임/타이틀</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='카메라DSLR')}" href="#">
-                                                <span class="widget-filter-item-text">카메라DSLR</span>
+                                               th:href="@{/shop/(first='디지털', second='카메라/DSLR')}" href="#">
+                                                <span class="widget-filter-item-text">카메라/DSLR</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='디지털', first='PC부품저장장치')}" href="#">
-                                                <span class="widget-filter-item-text">PC부품저장장치</span>
+                                               th:href="@{/shop/(first='디지털', second='PC부품/저장장치')}" href="#">
+                                                <span class="widget-filter-item-text">PC부품/저장장치</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -444,93 +444,93 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='골프')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='골프')}" href="#">
                                                 <span class="widget-filter-item-text">골프</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='캠핑')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='캠핑')}" href="#">
                                                 <span class="widget-filter-item-text">캠핑</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='낚시')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='낚시')}" href="#">
                                                 <span class="widget-filter-item-text">낚시</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='축구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='축구')}" href="#">
                                                 <span class="widget-filter-item-text">축구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='자전거')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='자전거')}" href="#">
                                                 <span class="widget-filter-item-text">자전거</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='테니스')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='테니스')}" href="#">
                                                 <span class="widget-filter-item-text">테니스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='등산클라이밍')}" href="#">
-                                                <span class="widget-filter-item-text">등산클라이밍</span>
+                                               th:href="@{/shop/(first='스포츠', second='등산/클라이밍')}" href="#">
+                                                <span class="widget-filter-item-text">등산/클라이밍</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='헬스요가필라테스')}" href="#">
-                                                <span class="widget-filter-item-text">헬스요가필라테스</span>
+                                               th:href="@{/shop/(first='스포츠', second='헬스/요가/필라테스')}" href="#">
+                                                <span class="widget-filter-item-text">헬스/요가/필라테스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='야구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='야구')}" href="#">
                                                 <span class="widget-filter-item-text">야구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='볼링')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='볼링')}" href="#">
                                                 <span class="widget-filter-item-text">볼링</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='배트민턴')}" href="#">
-                                                <span class="widget-filter-item-text">배트민턴</span>
+                                               th:href="@{/shop/(first='스포츠', second='배드민턴')}" href="#">
+                                                <span class="widget-filter-item-text">배드민턴</span>
                                             </a>
 
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='탁구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='탁구')}" href="#">
                                                 <span class="widget-filter-item-text">탁구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='농구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='농구')}" href="#">
                                                 <span class="widget-filter-item-text">농구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='당구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠', second='당구')}" href="#">
                                                 <span class="widget-filter-item-text">당구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='스포츠', first='기타스포츠')}" href="#">
-                                                <span class="widget-filter-item-text">기타스포츠</span>
+                                               th:href="@{/shop/(first='스포츠', second='기타/스포츠')}" href="#">
+                                                <span class="widget-filter-item-text">기타/스포츠</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -552,26 +552,26 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='차량', first='국산차')}" href="#">
+                                               th:href="@{/shop/(first='차량', second='국산차')}" href="#">
                                                 <span class="widget-filter-item-text">국산차</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='차량', first='수입차')}" href="#">
+                                               th:href="@{/shop/(first='차량', second='수입차')}" href="#">
                                                 <span class="widget-filter-item-text">수입차</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='차량', first='차량용품부품')}" href="#">
-                                                <span class="widget-filter-item-text">차량용품부품</span>
+                                               th:href="@{/shop/(first='차량', second='차량/용품부품')}" href="#">
+                                                <span class="widget-filter-item-text">차량/용품부품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='차량', first='오토바이용품부품')}" href="#">
-                                                <span class="widget-filter-item-text">오토바이용품부품</span>
+                                               th:href="@{/shop/(first='차량', second='오토바이 용품/부품')}" href="#">
+                                                <span class="widget-filter-item-text">오토바이 용품/부품</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -593,19 +593,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='굿즈', first='보이그룹')}" href="#">
+                                               th:href="@{/shop/(first='굿즈', second='보이그룹')}" href="#">
                                                 <span class="widget-filter-item-text">보이그룹</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='굿즈', first='걸그룹')}" href="#">
+                                               th:href="@{/shop/(first='굿즈', second='걸그룹')}" href="#">
                                                 <span class="widget-filter-item-text">걸그룹</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='굿즈류', first='방송예능캐릭터')}" href="#">
+                                               th:href="@{/shop/(first='굿즈류', second='방송예능캐릭터')}" href="#">
                                                 <span class="widget-filter-item-text">방송예능캐릭터</span>
                                             </a>
                                         </li>
@@ -628,19 +628,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='예술', first='희귀수집품')}" href="#">
-                                                <span class="widget-filter-item-text">희귀수집품</span>
+                                               th:href="@{/shop/(first='예술', second='희귀/수집품')}" href="#">
+                                                <span class="widget-filter-item-text">희귀/수집품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='예술', first='골동품')}" href="#">
+                                               th:href="@{/shop/(first='예술', second='골동품')}" href="#">
                                                 <span class="widget-filter-item-text">골동품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='예술', first='예술작품')}" href="#">
+                                               th:href="@{/shop/(first='예술', second='예술작품')}" href="#">
                                                 <span class="widget-filter-item-text">예술작품</span>
                                             </a>
                                         </li>
@@ -664,13 +664,13 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='악기', first='CDDVDLP')}" href="#">
-                                                <span class="widget-filter-item-text">CDDVDLP</span>
+                                               th:href="@{/shop/(first='악기', second='CD/DVD/LP')}" href="#">
+                                                <span class="widget-filter-item-text">CD/DVD/LP</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='악기', first='악기')}" href="#">
+                                               th:href="@{/shop/(first='악기', second='악기')}" href="#">
                                                 <span class="widget-filter-item-text">악기</span>
                                             </a>
                                         </li>
@@ -693,31 +693,31 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='도서', first='도서')}" href="#">
+                                               th:href="@{/shop/(first='도서', second='도서')}" href="#">
                                                 <span class="widget-filter-item-text">도서</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='도서', first='문구')}" href="#">
+                                               th:href="@{/shop/(first='도서', second='문구')}" href="#">
                                                 <span class="widget-filter-item-text">문구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='도서', first='기프티콘쿠폰')}" href="#">
-                                                <span class="widget-filter-item-text">기프티콘쿠폰</span>
+                                               th:href="@{/shop/(first='도서', second='기프티콘/쿠폰')}" href="#">
+                                                <span class="widget-filter-item-text">기프티콘/쿠폰</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='도서', first='상품권')}" href="#">
+                                               th:href="@{/shop/(first='도서', second='상품권')}" href="#">
                                                 <span class="widget-filter-item-text">상품권</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='도서', first='티켓')}" href="#">
+                                               th:href="@{/shop/(first='도서', second='티켓')}" href="#">
                                                 <span class="widget-filter-item-text">티켓</span>
                                             </a>
                                         </li>
@@ -741,56 +741,56 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='스킨케어')}" href="#">
+                                               th:href="@{/shop/(first='뷰티', second='스킨케어')}" href="#">
                                                 <span class="widget-filter-item-text">스킨케어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='색조메이크업')}" href="#">
+                                               th:href="@{/shop/(first='뷰티', second='색조메이크업')}" href="#">
                                                 <span class="widget-filter-item-text">색조메이크업</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='베이스메이크업')}" href="#">
+                                               th:href="@{/shop/(first='뷰티', second='베이스메이크업')}" href="#">
                                                 <span class="widget-filter-item-text">베이스메이크업</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='바디헤어케어')}" href="#">
-                                                <span class="widget-filter-item-text">바디헤어케어</span>
+                                               th:href="@{/shop/(first='뷰티', second='바디/헤어케어')}" href="#">
+                                                <span class="widget-filter-item-text">바디/헤어케어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='향수아로마')}" href="#">
-                                                <span class="widget-filter-item-text">향수아로마</span>
+                                               th:href="@{/shop/(first='뷰티', second='향수/아로마')}" href="#">
+                                                <span class="widget-filter-item-text">향수/아로마</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='네일아트케어')}" href="#">
-                                                <span class="widget-filter-item-text">네일아트케어</span>
+                                               th:href="@{/shop/(first='뷰티', second='네일/아트케어')}" href="#">
+                                                <span class="widget-filter-item-text">네일/아트케어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='미용소품기기')}" href="#">
-                                                <span class="widget-filter-item-text">미용소품기기</span>
+                                               th:href="@{/shop/(first='뷰티', second='미용소품/기기')}" href="#">
+                                                <span class="widget-filter-item-text">미용소품/기기</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='아티어트이너뷰티')}" href="#">
-                                                <span class="widget-filter-item-text">아티어트이너뷰티</span>
+                                               th:href="@{/shop/(first='뷰티', second='다이어트/이너뷰티')}" href="#">
+                                                <span class="widget-filter-item-text">다이어트/이너뷰티</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='뷰티', first='남성화장품')}" href="#">
-                                                <span class="widget-filter-item-text">남성화장품</span>
+                                               th:href="@{/shop/(first='뷰티', second='남성 화장품')}" href="#">
+                                                <span class="widget-filter-item-text">남성 화장품</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -812,13 +812,13 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='가구', first='인테리어')}" href="#">
+                                               th:href="@{/shop/(first='가구', second='인테리어')}" href="#">
                                                 <span class="widget-filter-item-text">인테리어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='가구', first='가구')}" href="#">
+                                               th:href="@{/shop/(first='가구', second='가구')}" href="#">
                                                 <span class="widget-filter-item-text">가구</span>
                                             </a>
                                         </li>
@@ -841,25 +841,25 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='생활', first='주방용품')}" href="#">
+                                               th:href="@{/shop/(first='생활', second='주방용품')}" href="#">
                                                 <span class="widget-filter-item-text">주방용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='생활', first='식품')}" href="#">
+                                               th:href="@{/shop/(first='생활', second='식품')}" href="#">
                                                 <span class="widget-filter-item-text">식품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='생활', first='생활용품')}" href="#">
+                                               th:href="@{/shop/(first='생활', second='생활용품')}" href="#">
                                                 <span class="widget-filter-item-text">생활용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='생활', first='산업용품')}" href="#">
+                                               th:href="@{/shop/(first='생활', second='산업용품')}" href="#">
                                                 <span class="widget-filter-item-text">산업용품</span>
                                             </a>
                                         </li>
@@ -882,38 +882,39 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='아동', first='베이비의류')}" href="#">
-                                                <span class="widget-filter-item-text">베이비의류</span>
+                                               th:href="@{/shop/(first='아동', second='베이비의류(0-2세)')}" href="#">
+                                                <span class="widget-filter-item-text">베이비의류(0-2세)</span>
+                                            </a>
+                                        </li>
+
+                                        <li class="widget-list-item widget-filter-item">
+                                            <a class="widget-list-link d-flex justify-content-between align-items-center"
+                                               th:href="@{/shop/(first='아동', second='유아동신발/잡화')}" href="#">
+                                                <span class="widget-filter-item-text">유아동신발/잡화</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='아동', first='유아동신발잡화')}" href="#">
-                                                <span class="widget-filter-item-text">유아동신발잡화</span>
+                                               th:href="@{/shop/(first='아동', second='교육/완구/인형')}" href="#">
+                                                <span class="widget-filter-item-text">교육/완구/인형</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='아동', first='교육완구인형')}" href="#">
-                                                <span class="widget-filter-item-text">교육완구인형</span>
-                                            </a>
-                                        </li>
-                                        <li class="widget-list-item widget-filter-item">
-                                            <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='아동', first='유아용품')}" href="#">
+                                               th:href="@{/shop/(first='아동', second='유아용품')}" href="#">
                                                 <span class="widget-filter-item-text">유아용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='아동', first='출산임부용품')}" href="#">
-                                                <span class="widget-filter-item-text">출산임부용품</span>
+                                               th:href="@{/shop/(first='아동', second='출산/임부용품')}" href="#">
+                                                <span class="widget-filter-item-text">출산/임부용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='아동', first='이유용품유아식기')}" href="#">
-                                                <span class="widget-filter-item-text">이유용품유아식기</span>
+                                               th:href="@{/shop/(first='아동', second='이유용품/유아식기')}" href="#">
+                                                <span class="widget-filter-item-text">이유용품/유아식기</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -935,26 +936,32 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='동물', first='강아지')}" href="#">
+                                               th:href="@{/shop/(first='동물', second='강아지 용품')}" href="#">
                                                 <span class="widget-filter-item-text">강아지</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='동물', first='고양이')}" href="#">
+                                               th:href="@{/shop/(first='동물', second='고양이 용품')}" href="#">
                                                 <span class="widget-filter-item-text">고양이</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='동물', first='기타용품')}" href="#">
+                                               th:href="@{/shop/(first='동물', second='기타용품')}" href="#">
                                                 <span class="widget-filter-item-text">기타용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(category='동물', first='사료간식')}" href="#">
-                                                <span class="widget-filter-item-text">사료간식</span>
+                                               th:href="@{/shop/(first='동물', second='강아지 사료/간식')}" href="#">
+                                                <span class="widget-filter-item-text">강아지 사료/간식</span>
+                                            </a>
+                                        </li>
+                                        <li class="widget-list-item widget-filter-item">
+                                            <a class="widget-list-link d-flex justify-content-between align-items-center"
+                                               th:href="@{/shop/(first='동물', second='고양이 사료/간식')}" href="#">
+                                                <span class="widget-filter-item-text">고양이 사료/간식</span>
                                             </a>
                                         </li>
                                     </ul>

--- a/src/test/java/SilkLoad/controller/ShopControllerTest.java
+++ b/src/test/java/SilkLoad/controller/ShopControllerTest.java
@@ -1,0 +1,49 @@
+package SilkLoad.controller;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import SilkLoad.controller.Shop.ShopController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * @WebMvcTest - JPA 기능은 동작하지 않는다.
+ * - 여러 스프링 테스트 어노테이션 중, Web(Spring MVC)에만 집중할 수 있는 어노테이션
+ * - @Controller, @ControllerAdvice 사용 가능
+ * - 단, @Service, @Repository등은 사용할 수 없다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ShopControllerTest {
+    /**
+     * 웹 API 테스트할 때 사용
+     * 스프링 MVC 테스트의 시작점
+     * HTTP GET,POST 등에 대해 API 테스트 가능
+     * */
+    // 아래 BeforeEach 에서 mockMvc 객체를 초기화 하는 것과 같다.
+    @Autowired
+    public MockMvc mvc;
+
+    @Test
+    @DisplayName("Shop컨트롤러 테스트")
+    void HelloControllerDtoTest() throws Exception {
+        //given
+        String name = "Test";
+        //then
+        mvc.perform(get("/shop")
+                        .param("first", name)
+                        .param("second", name)
+                        .param("third", name)
+                )
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/SilkLoad/example/service/ProductServiceTest.java
+++ b/src/test/java/SilkLoad/example/service/ProductServiceTest.java
@@ -64,15 +64,7 @@ public class ProductServiceTest {
         System.out.println("product = " + product);
     }
 
-    @Test
-    void 물품_가져오기_테스트(){
-        List<ProductRecordDto> allProduct = productService.findAllProduct();
-        ProductRecordDto byId_product = productService.findById_ProductRecordDto(5L);
-//        System.out.println("byId_product = " + byId_product);
-        for (ProductRecordDto product : allProduct) {
-            System.out.println("product = " + product.getProductImagesList().get(0).getStoreFileName());
-        }
-    }
+
 
     @Test
     void productLazeTest() throws IOException {

--- a/src/test/java/SilkLoad/repository/CategoryRepositoryTest.java
+++ b/src/test/java/SilkLoad/repository/CategoryRepositoryTest.java
@@ -49,36 +49,36 @@ class CategoryRepositoryTest {
 
     @Test
     @Transactional
-    @Rollback(value = false)
+//    @Rollback(value = false)
     void 카테고리_물품넣기_테스트() throws IOException {
 
-        Product product = productRepository.findById((long) 1).get();
+//        Product product = productRepository.findById((long) 1).get();
+//
+//        //더미 이미지 만들기, jpg -> MultipartFile로 만들기가 힘들다
+//        List<MultipartFile> imageFiles = List.of(
+//                new MockMultipartFile("7a88ca37-9e3b-4be3-af72-1bd6e5b7fe9f.jpg",
+//                        "7a88ca37-9e3b-4be3-af72-1bd6e5b7fe9f.jpg",
+//                        MediaType.IMAGE_JPEG_VALUE,
+//                        "test1".getBytes())
+//        );
+//        //새로운 물품 만들기
+//        ProductFormDto test_product = ProductFormDto.builder()
+//                .name("test입니다.")
+//                .instancePrice(1234L)
+//                .auctionPrice(1234L)
+//                .Explanation("test입니다.")
+//                .category("여성의류,코트,겨울")
+//                .imageFileList(imageFiles)
+//                .productTime(ProductTime.NONE)
+//                .build();
+//
+//        //DB에 있는 memeber 가지고 오기, member가 정해지지 않으면 영속성에서 외래키 오류가 발생한다
+//        Members members = memberRepository.findById((long) 1).get();
+//        productService.save(test_product, members);
 
-        //더미 이미지 만들기, jpg -> MultipartFile로 만들기가 힘들다
-        List<MultipartFile> imageFiles = List.of(
-                new MockMultipartFile("7a88ca37-9e3b-4be3-af72-1bd6e5b7fe9f.jpg",
-                        "7a88ca37-9e3b-4be3-af72-1bd6e5b7fe9f.jpg",
-                        MediaType.IMAGE_JPEG_VALUE,
-                        "test1".getBytes())
-        );
-        //새로운 물품 만들기
-        ProductFormDto test_product = ProductFormDto.builder()
-                .name("test입니다.")
-                .instancePrice(1234L)
-                .auctionPrice(1234L)
-                .Explanation("test입니다.")
-                .category("여성의류,코트,겨울")
-                .imageFileList(imageFiles)
-                .productTime(ProductTime.NONE)
-                .build();
-
-        //DB에 있는 memeber 가지고 오기, member가 정해지지 않으면 영속성에서 외래키 오류가 발생한다
-        Members members = memberRepository.findById((long) 1).get();
-        productService.save(test_product, members);
 
 
-
-        String s = "여성의류,코트,겨울";
+        String s = "여성의류,맨투맨,맨투맨";
         List<String> collect = Arrays.asList(s.split(",")).stream().collect(Collectors.toList());
         Category all = categoryRepository.findByFirstAndSecondAndThird(collect.get(0), collect.get(1), collect.get(2)).get();
 //        categoryRepository.save(all.get(0));


### PR DESCRIPTION
## ✏Change Details

- shopSider.html에 카테고리 crawling 데이터 카테고리로 변경 
- 쿼리스트링 category, first => first, second 로 변경


## 💬Comment

- 크롤링 카테고리 2차 기준으로 화면에 보여준다.
- 아직 detailPage는 구성안됨
- detailPage에 들어가면 3차 카테고리 기준으로 크롤링 데이터 보여주기 구현해야 함

(7/3)
- detailPage에 들어가면 3차 카테고리를 기준으로 번개장터 물품 가져온다.
- 번개 장터 크롤링 category랑 category 테이블 카테고리를 맞춰야 할듯

(7/5)
-  ShopController 테스트코드 작성 
-  MockMvc를 통해 주고 받기 가능

## 📑References

(테스트 코드 알아보기)
- https://tech.devgd.com/12
- https://dev-gorany.tistory.com/354

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?