### PR TITLE
화면이 작아졌을 때 아래 나오는 메뉴 정리

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -356,18 +356,33 @@
 </main>
 
 <div class="handheld-toolbar">
-    <div class="d-table table-layout-fixed w-100"><a class="d-table-cell handheld-toolbar-item"
-                                                     href="myPage/memberWishlist.html"><span class="handheld-toolbar-icon"><i
-            class="ci-heart"></i></span><span class="handheld-toolbar-label">Wishlist</span></a><a
-            class="d-table-cell handheld-toolbar-item" href="javascript:void(0)" data-bs-toggle="collapse"
-            data-bs-target="#navbarCollapse" onclick="window.scrollTo(0, 0)"><span class="handheld-toolbar-icon"><i
-            class="ci-menu"></i></span><span class="handheld-toolbar-label">Menu</span></a><a
-            class="d-table-cell handheld-toolbar-item" href="shop-cart.html"><span class="handheld-toolbar-icon"><i
-            class="ci-cart"></i><span class="badge bg-primary rounded-pill ms-1">4</span></span><span
-            class="handheld-toolbar-label">$265.00</span></a></div>
+    <div class="d-table table-layout-fixed w-100">
+        <a class="d-table-cell handheld-toolbar-item" th:href="@{/members/myPage/wishlist}">
+            <span class="handheld-toolbar-icon">
+                <i class="ci-heart"></i>
+            </span>
+            <span class="handheld-toolbar-label">Wishlist</span>
+        </a>
+
+        <a class="d-table-cell handheld-toolbar-item" href="javascript:void(0)" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" onclick="window.scrollTo(0, 0)">
+        <span class="handheld-toolbar-icon">
+            <i class="ci-menu"></i>
+        </span>
+            <span class="handheld-toolbar-label">Menu
+        </span>
+        </a>
+
+        <a class="d-table-cell handheld-toolbar-item" th:href="@{/members/myPage/wishlist}">
+            <span class="handheld-toolbar-icon">
+                <i class="ci-cart"></i>
+                <span class="badge bg-primary rounded-pill ms-1">4</span></span>
+            <span class="handheld-toolbar-label">$265.00</span>
+        </a>
+    </div>
 </div>
 <!-- Back To Top Button--><a class="btn-scroll-top" href="#top" data-scroll><span
-        class="btn-scroll-top-tooltip text-muted fs-sm me-2">Top</span><i class="btn-scroll-top-icon ci-arrow-up"> </i></a>
+        class="btn-scroll-top-tooltip text-muted fs-sm me-2">Top</span>
+    <i class="btn-scroll-top-icon ci-arrow-up"> </i></a>
 <script th:inline="javascript">
 
 

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -136,16 +136,23 @@
 </div>
 
 <div class="handheld-toolbar">
-    <div class="d-table table-layout-fixed w-100"><a class="d-table-cell handheld-toolbar-item"
-                                                     href="myPage/memberWishlist.html"><span
-            class="handheld-toolbar-icon"><i
-            class="ci-heart"></i></span><span class="handheld-toolbar-label">Wishlist</span></a><a
-            class="d-table-cell handheld-toolbar-item" href="javascript:void(0)" data-bs-toggle="collapse"
-            data-bs-target="#navbarCollapse" onclick="window.scrollTo(0, 0)"><span class="handheld-toolbar-icon"><i
-            class="ci-menu"></i></span><span class="handheld-toolbar-label">Menu</span></a><a
-            class="d-table-cell handheld-toolbar-item" href="shop-cart.html"><span class="handheld-toolbar-icon"><i
-            class="ci-cart"></i><span class="badge bg-primary rounded-pill ms-1">4</span></span><span
-            class="handheld-toolbar-label">$265.00</span></a></div>
+    <div class="d-table table-layout-fixed w-100">
+
+        <a class="d-table-cell handheld-toolbar-item" href="javascript:void(0)" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" onclick="window.scrollTo(0, 0)">
+        <span class="handheld-toolbar-icon">
+            <i class="ci-menu"></i>
+        </span>
+            <span class="handheld-toolbar-label">메뉴
+        </span>
+        </a>
+
+        <a class="d-table-cell handheld-toolbar-item" th:href="@{/members/myPage/wishlist}">
+            <span class="handheld-toolbar-icon">
+                <i class="ci-cart"></i>
+            </span>
+            <span class="handheld-toolbar-label">장바구니</span>
+        </a>
+    </div>
 </div>
 
 <!-- Back To Top Button--><a class="btn-scroll-top" href="#top" data-scroll><span


### PR DESCRIPTION
## 📌Linked Issues

- 

## ✏Change Details

- layout.html의 컨텐츠 들만 수정
- 3개의 메뉴가 있었는데 2개가 장바구니, wishlist 라서 1개로 축소

## 💬Comment

- index.html에 있는 메뉴는 화면에 안나오는 듯? 
- 화면의 하나씩 고처나갈 예정

## 📑References

- 

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?