### PR TITLE
3차 카테고리 쿼리문 수정, detailPage 상세설명 방법 변경

### DIFF
--- a/src/main/java/SilkLoad/controller/Product/ProductController.java
+++ b/src/main/java/SilkLoad/controller/Product/ProductController.java
@@ -45,7 +45,6 @@ public class ProductController {
                               BindingResult bindingResult,
                               HttpServletRequest request) throws IOException {
 
-        System.out.println(productData);
         if (bindingResult.hasErrors()) {
             if (productData.getCategory().isEmpty()) {
                 bindingResult.reject("addCategoryFail", "카테고리 입력은 필수입니다! 3차 카테고리까지 모두 입력해주세요.");

--- a/src/main/java/SilkLoad/repository/CategoryRepository.java
+++ b/src/main/java/SilkLoad/repository/CategoryRepository.java
@@ -14,6 +14,9 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     //1차,2차,3차 카테고리를 받아서 Category엔티티를 반환한다.
     //거기에는 productList가 들어있다.
+//    @EntityGraph("CategoryWithProduct")
+//    Optional<Category> findByFirstAndSecondAndThird(String first, String second, String third);
+    //Contains로 Like를 쿼리에 넣음
     @EntityGraph("CategoryWithProduct")
-    Optional<Category> findByFirstAndSecondAndThird(String first, String second, String third);
+    Optional<Category> findByFirstAndSecondAndThirdContains(String first, String second, String third);
 }

--- a/src/main/java/SilkLoad/repository/CrawlingRepository.java
+++ b/src/main/java/SilkLoad/repository/CrawlingRepository.java
@@ -10,11 +10,10 @@ import org.springframework.data.domain.Pageable;
 public interface CrawlingRepository extends JpaRepository<Crawling, Long> {
 
     Page<Crawling> findByFirst(String first, Pageable pageable);
-//    Page<Crawling> findBySecond(String second, Pageable pageable);
-//    Page<Crawling> findByThird(String third, Pageable pageable);
+
 
     //first, second, third 카테고리를 기준으로 crwaling db에서 데이터 가져오는 쿼리
-    Page<Crawling> findByFirstAndSecondAndThird(String first, String second, String third, Pageable pageable);
+    Page<Crawling> findByFirstAndSecondAndThirdContains(String first, String second, String third, Pageable pageable);
 
     //first, second,카테고리를 기준으로 crwaling db에서 데이터 가져오는 쿼리
     Page<Crawling> findByFirstAndSecond(String first, String second, Pageable pageable);

--- a/src/main/java/SilkLoad/service/CrawlingService.java
+++ b/src/main/java/SilkLoad/service/CrawlingService.java
@@ -59,7 +59,7 @@ public class CrawlingService {
     @Transactional(readOnly = true)
     public Page<CrawlingDto> getcrawlingdataFirstSecondThird(Pageable pageable,String first, String second ,String third) {
         Page<CrawlingDto> data = crawlingRepository
-                .findByFirstAndSecondAndThird(first, second, third, pageable)
+                .findByFirstAndSecondAndThirdContains(first, second, third, pageable)
                 .map(this::ToCrawlingDto);
         return data;
     }

--- a/src/main/java/SilkLoad/service/ProductService.java
+++ b/src/main/java/SilkLoad/service/ProductService.java
@@ -107,7 +107,7 @@ public class ProductService {
         String[] splitCategory = categoryName.split(",");
 
         Optional<Category> categoryWithProduct = categoryRepository.
-                findByFirstAndSecondAndThird(splitCategory[0], splitCategory[1], splitCategory[2]);
+                findByFirstAndSecondAndThirdContains(splitCategory[0], splitCategory[1], splitCategory[2]);
 
         if (!categoryWithProduct.isPresent()) { // 존재하지 않는다면
             category = Category.builder()

--- a/src/main/resources/templates/addProductForm.html
+++ b/src/main/resources/templates/addProductForm.html
@@ -144,7 +144,7 @@
                                             <button type="button" class="btn">시계/쥬얼리</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">패션악세서리</button>
+                                            <button type="button" class="btn">패션 엑세서리</button>
                                         </li>
                                         <li class="lii">
                                             <button type="button" class="btn">디지털/가전</button>
@@ -382,13 +382,13 @@
                                             <button type="button" class="btn">pc노트북</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">게임타이틀</button>
+                                            <button type="button" class="btn">게임/타이틀</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">카메라/dslr</button>
+                                            <button type="button" class="btn">카메라/DSLR</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">pc부품저장장치</button>
+                                            <button type="button" class="btn">pc부품/저장장치</button>
                                         </li>
                                     </ul>
                                     <ul class="ull" id="sportsLeisure" style="display: none">
@@ -545,7 +545,7 @@
                                             <button type="button" class="btn">다이어트</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">남성화장품</button>
+                                            <button type="button" class="btn">남성 화장품</button>
                                         </li>
                                     </ul>
                                     <ul class="ull" id="furnitureInterior" style="display: none">
@@ -572,13 +572,13 @@
                                     </ul>
                                     <ul class="ull" id="infantMaternity" style="display: none">
                                         <li class="lii">
-                                            <button type="button" class="btn">베이비의류</button>
+                                            <button type="button" class="btn">베이비의류(0-2세)</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">여아의류</button>
+                                            <button type="button" class="btn">여아의류(3-6세)</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">남아의류</button>
+                                            <button type="button" class="btn">남아의류(3-6세)</button>
                                         </li>
                                         <li class="lii">
                                             <button type="button" class="btn">유아동신발/잡화</button>
@@ -1142,10 +1142,10 @@
                                     </ul>
                                     <ul class="ull" id="watch" style="display: none">
                                         <li class="lii">
-                                            <button type="button" class="btn">남성시계</button>
+                                            <button type="button" class="btn">남성 시계</button>
                                         </li>
                                         <li class="lii">
-                                            <button type="button" class="btn">여성시계</button>
+                                            <button type="button" class="btn">여성 시계</button>
                                         </li>
                                         <li class="lii">
                                             <button type="button" class="btn">기타</button>
@@ -2639,7 +2639,7 @@
                 $("#bagMiddle").show();
             } else if (e.target.innerText == "시계/쥬얼리") {
                 $("#watchJewelryMiddle").show();
-            } else if (e.target.innerText == "패션악세서리") {
+            } else if (e.target.innerText == "패션 엑세서리") {
                 $("#fashionAccessoriesMiddle").show();
             } else if (e.target.innerText == "디지털/가전") {
                 $("#digitalHomeApplicanceMiddle").show();
@@ -2788,7 +2788,7 @@
                 } else if (e.target.innerText == "쥬얼리") {
                     $("#jewelry").show();
                 }
-            } else if (bigCategoryValue == "패션악세서리") {
+            } else if (bigCategoryValue == "패션 엑세서리") {
                 if (e.target.innerText == "지갑") {
                     $("#wallet").show();
                 } else if (e.target.innerText == "벨트") {

--- a/src/main/resources/templates/detailProduct.html
+++ b/src/main/resources/templates/detailProduct.html
@@ -424,11 +424,13 @@
                             <!-- Product panels-->
                             <div class="accordion mb-4" id="productPanels">
                                 <div class="accordion-item">
-                                    <h3 class="accordion-header"><a class="accordion-button" href="#productInfo"
+                                    <h3 class="accordion-header">
+                                        <a class="accordion-button" href="#productInfo"
                                                                     role="button" data-bs-toggle="collapse"
                                                                     aria-expanded="true" aria-controls="productInfo">
-                                        <i class="ci-announcement text-muted fs-lg align-middle mt-n1 me-2"></i>Product
-                                        info</a>
+                                        <i class="ci-announcement text-muted fs-lg align-middle mt-n1 me-2"></i>
+                                        물품 상세 설명
+                                        </a>
                                     </h3>
                                     <div class="accordion-collapse collapse show" id="productInfo"
                                          data-bs-parent="#productPanels">
@@ -450,7 +452,9 @@
 
                                             <h6 class="fs-sm mb-2">상세 설명</h6>
                                             <ul class="fs-sm ps-4">
-                                                <li class="" th:text="${ product.explanation }"></li>
+                                                <!--자동 줄바꿈 word-break -->
+                                                 <div style="word-break: break-all" rows="6"
+                                                           th:text="${ product.explanation }"></div>
                                             </ul>
 
 
@@ -499,11 +503,6 @@
                                 <i class="ci-store fs-lg me-2"></i>경매 구매
                             </button>
 
-                            <!-- Sharing-->
-                            <label class="form-label d-inline-block align-middle my-2 me-3">Share:</label><a
-                                class="btn-share btn-twitter me-2 my-2" href="#"><i class="ci-twitter"></i>Twitter</a><a
-                                class="btn-share btn-instagram me-2 my-2" href="#"><i class="ci-instagram"></i>Instagram</a><a
-                                class="btn-share btn-facebook my-2" href="#"><i class="ci-facebook"></i>Facebook</a>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/shopSidebar.html
+++ b/src/main/resources/templates/shopSidebar.html
@@ -60,6 +60,12 @@
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
+                                               th:href="@{/shop/(first='여성의류', second='블라우스')}"  href="#">
+                                                <span class="widget-filter-item-text">블라우스</span>
+                                            </a>
+                                        </li>
+                                        <li class="widget-list-item widget-filter-item">
+                                            <a class="widget-list-link d-flex justify-content-between align-items-center"
                                                th:href="@{/shop/(first='여성의류', second='셔츠')}"  href="#">
                                                 <span class="widget-filter-item-text">셔츠</span>
                                             </a>
@@ -220,7 +226,7 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='신발', second='가디건')}" href="#">
+                                               th:href="@{/shop/(first='신발', second='스니커즈')}" href="#">
                                                 <span class="widget-filter-item-text">스니커즈</span>
                                             </a>
                                         </li>
@@ -291,13 +297,13 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='시계', second='시계')}" href="#">
+                                               th:href="@{/shop/(first='시계/쥬얼리', second='시계')}" href="#">
                                                 <span class="widget-filter-item-text">시계</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='시계', second='쥬얼리')}" href="#">
+                                               th:href="@{/shop/(first='시계/쥬얼리', second='쥬얼리')}" href="#">
                                                 <span class="widget-filter-item-text">쥬얼리</span>
                                             </a>
                                         </li>
@@ -320,49 +326,49 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='지갑')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='지갑')}" href="#">
                                                 <span class="widget-filter-item-text">지갑</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='벨트')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='벨트')}" href="#">
                                                 <span class="widget-filter-item-text">벨트</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='모자')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='모자')}" href="#">
                                                 <span class="widget-filter-item-text">모자</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='스카프/넥타이')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='스카프/넥타이')}" href="#">
                                                 <span class="widget-filter-item-text">스카프/넥타이</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='안경/선글라스')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='안경/선글라스')}" href="#">
                                                 <span class="widget-filter-item-text">안경/선글라스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='양말/스타킹')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='양말/스타킹')}" href="#">
                                                 <span class="widget-filter-item-text">양말/스타킹</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='우산/양산')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='우산/양산')}" href="#">
                                                 <span class="widget-filter-item-text">우산/양산</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='패션', second='기타 액세서리')}" href="#">
+                                               th:href="@{/shop/(first='패션 액세서리', second='기타 액세서리')}" href="#">
                                                 <span class="widget-filter-item-text">기타/악세서리</span>
                                             </a>
                                         </li>
@@ -385,43 +391,43 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='모바일')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='모바일')}" href="#">
                                                 <span class="widget-filter-item-text">모바일</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='가전제품')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='가전제품')}" href="#">
                                                 <span class="widget-filter-item-text">가전제품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='오디오/영상/관련기기')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='오디오/영상/관련기기')}" href="#">
                                                 <span class="widget-filter-item-text">오디오/영상/관련기기</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='PC/노트북')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='PC/노트북')}" href="#">
                                                 <span class="widget-filter-item-text">PC/노트북</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='게임/타이틀')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='게임/타이틀')}" href="#">
                                                 <span class="widget-filter-item-text">게임/타이틀</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='카메라/DSLR')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='카메라/DSLR')}" href="#">
                                                 <span class="widget-filter-item-text">카메라/DSLR</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='디지털', second='PC부품/저장장치')}" href="#">
+                                               th:href="@{/shop/(first='디지털/가전', second='PC부품/저장장치')}" href="#">
                                                 <span class="widget-filter-item-text">PC부품/저장장치</span>
                                             </a>
                                         </li>
@@ -444,93 +450,87 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='골프')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='골프')}" href="#">
                                                 <span class="widget-filter-item-text">골프</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='캠핑')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='캠핑')}" href="#">
                                                 <span class="widget-filter-item-text">캠핑</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='낚시')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='낚시')}" href="#">
                                                 <span class="widget-filter-item-text">낚시</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='축구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='축구')}" href="#">
                                                 <span class="widget-filter-item-text">축구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='자전거')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='자전거')}" href="#">
                                                 <span class="widget-filter-item-text">자전거</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='테니스')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='테니스')}" href="#">
                                                 <span class="widget-filter-item-text">테니스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='등산/클라이밍')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='등산/클라이밍')}" href="#">
                                                 <span class="widget-filter-item-text">등산/클라이밍</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='헬스/요가/필라테스')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='헬스/요가/필라테스')}" href="#">
                                                 <span class="widget-filter-item-text">헬스/요가/필라테스</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='야구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='야구')}" href="#">
                                                 <span class="widget-filter-item-text">야구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='볼링')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='볼링')}" href="#">
                                                 <span class="widget-filter-item-text">볼링</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='배드민턴')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='배드민턴')}" href="#">
                                                 <span class="widget-filter-item-text">배드민턴</span>
                                             </a>
 
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='탁구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='탁구')}" href="#">
                                                 <span class="widget-filter-item-text">탁구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='농구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='농구')}" href="#">
                                                 <span class="widget-filter-item-text">농구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='당구')}" href="#">
+                                               th:href="@{/shop/(first='스포츠/레저', second='당구')}" href="#">
                                                 <span class="widget-filter-item-text">당구</span>
-                                            </a>
-                                        </li>
-                                        <li class="widget-list-item widget-filter-item">
-                                            <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='스포츠', second='기타/스포츠')}" href="#">
-                                                <span class="widget-filter-item-text">기타/스포츠</span>
                                             </a>
                                         </li>
                                     </ul>
@@ -552,25 +552,25 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='차량', second='국산차')}" href="#">
+                                               th:href="@{/shop/(first='차량/오토바이', second='국산차')}" href="#">
                                                 <span class="widget-filter-item-text">국산차</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='차량', second='수입차')}" href="#">
+                                               th:href="@{/shop/(first='차량/오토바이', second='수입차')}" href="#">
                                                 <span class="widget-filter-item-text">수입차</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='차량', second='차량/용품부품')}" href="#">
+                                               th:href="@{/shop/(first='차량/오토바이', second='차량 용품/부품')}" href="#">
                                                 <span class="widget-filter-item-text">차량/용품부품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='차량', second='오토바이 용품/부품')}" href="#">
+                                               th:href="@{/shop/(first='차량/오토바이', second='오토바이 용품/부품')}" href="#">
                                                 <span class="widget-filter-item-text">오토바이 용품/부품</span>
                                             </a>
                                         </li>
@@ -593,19 +593,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='굿즈', second='보이그룹')}" href="#">
+                                               th:href="@{/shop/(first='스타굿즈', second='보이그룹')}" href="#">
                                                 <span class="widget-filter-item-text">보이그룹</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='굿즈', second='걸그룹')}" href="#">
+                                               th:href="@{/shop/(first='스타굿즈', second='걸그룹')}" href="#">
                                                 <span class="widget-filter-item-text">걸그룹</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='굿즈류', second='방송예능캐릭터')}" href="#">
+                                               th:href="@{/shop/(first='스타굿즈', second='방송/예능/캐릭터')}" href="#">
                                                 <span class="widget-filter-item-text">방송예능캐릭터</span>
                                             </a>
                                         </li>
@@ -628,19 +628,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='예술', second='희귀/수집품')}" href="#">
+                                               th:href="@{/shop/(first='예술/희귀/수집품', second='희귀/수집품')}" href="#">
                                                 <span class="widget-filter-item-text">희귀/수집품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='예술', second='골동품')}" href="#">
+                                               th:href="@{/shop/(first='예술/희귀/수집품', second='골동품')}" href="#">
                                                 <span class="widget-filter-item-text">골동품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='예술', second='예술작품')}" href="#">
+                                               th:href="@{/shop/(first='예술/희귀/수집품', second='예술작품')}" href="#">
                                                 <span class="widget-filter-item-text">예술작품</span>
                                             </a>
                                         </li>
@@ -664,13 +664,13 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='악기', second='CD/DVD/LP')}" href="#">
+                                               th:href="@{/shop/(first='음반/악기', second='CD/DVD/LP')}" href="#">
                                                 <span class="widget-filter-item-text">CD/DVD/LP</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='악기', second='악기')}" href="#">
+                                               th:href="@{/shop/(first='음반/악기', second='악기')}" href="#">
                                                 <span class="widget-filter-item-text">악기</span>
                                             </a>
                                         </li>
@@ -693,31 +693,31 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='도서', second='도서')}" href="#">
+                                               th:href="@{/shop/(first='도서/티켓/문구', second='도서')}" href="#">
                                                 <span class="widget-filter-item-text">도서</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='도서', second='문구')}" href="#">
+                                               th:href="@{/shop/(first='도서/티켓/문구', second='문구')}" href="#">
                                                 <span class="widget-filter-item-text">문구</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='도서', second='기프티콘/쿠폰')}" href="#">
+                                               th:href="@{/shop/(first='도서/티켓/문구', second='기프티콘/쿠폰')}" href="#">
                                                 <span class="widget-filter-item-text">기프티콘/쿠폰</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='도서', second='상품권')}" href="#">
+                                               th:href="@{/shop/(first='도서/티켓/문구', second='상품권')}" href="#">
                                                 <span class="widget-filter-item-text">상품권</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='도서', second='티켓')}" href="#">
+                                               th:href="@{/shop/(first='도서/티켓/문구', second='티켓')}" href="#">
                                                 <span class="widget-filter-item-text">티켓</span>
                                             </a>
                                         </li>
@@ -741,55 +741,55 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='스킨케어')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='스킨케어')}" href="#">
                                                 <span class="widget-filter-item-text">스킨케어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='색조메이크업')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='색조메이크업')}" href="#">
                                                 <span class="widget-filter-item-text">색조메이크업</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='베이스메이크업')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='베이스메이크업')}" href="#">
                                                 <span class="widget-filter-item-text">베이스메이크업</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='바디/헤어케어')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='바디/헤어케어')}" href="#">
                                                 <span class="widget-filter-item-text">바디/헤어케어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='향수/아로마')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='향수/아로마')}" href="#">
                                                 <span class="widget-filter-item-text">향수/아로마</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='네일/아트케어')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='네일아트/케어')}" href="#">
                                                 <span class="widget-filter-item-text">네일/아트케어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='미용소품/기기')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='미용소품/기기')}" href="#">
                                                 <span class="widget-filter-item-text">미용소품/기기</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='다이어트/이너뷰티')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='다이어트/이너뷰티')}" href="#">
                                                 <span class="widget-filter-item-text">다이어트/이너뷰티</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='뷰티', second='남성 화장품')}" href="#">
+                                               th:href="@{/shop/(first='뷰티/미용', second='남성 화장품')}" href="#">
                                                 <span class="widget-filter-item-text">남성 화장품</span>
                                             </a>
                                         </li>
@@ -812,13 +812,13 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='가구', second='인테리어')}" href="#">
+                                               th:href="@{/shop/(first='가구/인테리어', second='인테리어')}" href="#">
                                                 <span class="widget-filter-item-text">인테리어</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='가구', second='가구')}" href="#">
+                                               th:href="@{/shop/(first='가구/인테리어', second='가구')}" href="#">
                                                 <span class="widget-filter-item-text">가구</span>
                                             </a>
                                         </li>
@@ -841,19 +841,19 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='생활', second='주방용품')}" href="#">
+                                               th:href="@{/shop/(first='생활/가공식품', second='주방용품')}" href="#">
                                                 <span class="widget-filter-item-text">주방용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='생활', second='식품')}" href="#">
+                                               th:href="@{/shop/(first='생활/가공식품', second='식품')}" href="#">
                                                 <span class="widget-filter-item-text">식품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='생활', second='생활용품')}" href="#">
+                                               th:href="@{/shop/(first='생활/가공식품', second='생활용품')}" href="#">
                                                 <span class="widget-filter-item-text">생활용품</span>
                                             </a>
                                         </li>
@@ -882,38 +882,38 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='아동', second='베이비의류(0-2세)')}" href="#">
+                                               th:href="@{/shop/(first='유아동/출산', second='베이비의류(0-2세)')}" href="#">
                                                 <span class="widget-filter-item-text">베이비의류(0-2세)</span>
                                             </a>
                                         </li>
 
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='아동', second='유아동신발/잡화')}" href="#">
+                                               th:href="@{/shop/(first='유아동/출산', second='유아동신발/잡화')}" href="#">
                                                 <span class="widget-filter-item-text">유아동신발/잡화</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='아동', second='교육/완구/인형')}" href="#">
+                                               th:href="@{/shop/(first='유아동/출산', second='교육/완구/인형')}" href="#">
                                                 <span class="widget-filter-item-text">교육/완구/인형</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='아동', second='유아용품')}" href="#">
+                                               th:href="@{/shop/(first='유아동/출산', second='유아용품')}" href="#">
                                                 <span class="widget-filter-item-text">유아용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='아동', second='출산/임부용품')}" href="#">
+                                               th:href="@{/shop/(first='유아동/출산', second='출산/임부용품')}" href="#">
                                                 <span class="widget-filter-item-text">출산/임부용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='아동', second='이유용품/유아식기')}" href="#">
+                                               th:href="@{/shop/(first='유아동/출산', second='이유용품/유아식기')}" href="#">
                                                 <span class="widget-filter-item-text">이유용품/유아식기</span>
                                             </a>
                                         </li>
@@ -928,7 +928,7 @@
                             <a class="accordion-button collapsed" href="#animal"
                                role="button" data-bs-toggle="collapse"
                                aria-expanded="false"
-                               aria-controls="men">동물</a></h3>
+                               aria-controls="men">반려동물용품</a></h3>
                         <div class="accordion-collapse collapse" id="animal" data-bs-parent="#shop-categories">
                             <div class="accordion-body">
                                 <div class="widget widget-links widget-filter">
@@ -936,31 +936,31 @@
                                         data-simplebar data-simplebar-auto-hide="false">
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='동물', second='강아지 용품')}" href="#">
+                                               th:href="@{/shop/(first='반려동물용품', second='강아지 용품')}" href="#">
                                                 <span class="widget-filter-item-text">강아지</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='동물', second='고양이 용품')}" href="#">
+                                               th:href="@{/shop/(first='반려동물용품', second='고양이 용품')}" href="#">
                                                 <span class="widget-filter-item-text">고양이</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='동물', second='기타용품')}" href="#">
+                                               th:href="@{/shop/(first='반려동물용품', second='기타(반려동물 용품)')}" href="#">
                                                 <span class="widget-filter-item-text">기타용품</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='동물', second='강아지 사료/간식')}" href="#">
+                                               th:href="@{/shop/(first='반려동물용품', second='강아지 사료/간식')}" href="#">
                                                 <span class="widget-filter-item-text">강아지 사료/간식</span>
                                             </a>
                                         </li>
                                         <li class="widget-list-item widget-filter-item">
                                             <a class="widget-list-link d-flex justify-content-between align-items-center"
-                                               th:href="@{/shop/(first='동물', second='고양이 사료/간식')}" href="#">
+                                               th:href="@{/shop/(first='반려동물용품', second='고양이 사료/간식')}" href="#">
                                                 <span class="widget-filter-item-text">고양이 사료/간식</span>
                                             </a>
                                         </li>

--- a/src/test/java/SilkLoad/repository/CategoryRepositoryTest.java
+++ b/src/test/java/SilkLoad/repository/CategoryRepositoryTest.java
@@ -80,7 +80,7 @@ class CategoryRepositoryTest {
 
         String s = "여성의류,맨투맨,맨투맨";
         List<String> collect = Arrays.asList(s.split(",")).stream().collect(Collectors.toList());
-        Category all = categoryRepository.findByFirstAndSecondAndThird(collect.get(0), collect.get(1), collect.get(2)).get();
+        Category all = categoryRepository.findByFirstAndSecondAndThirdContains(collect.get(0), collect.get(1), collect.get(2)).get();
 //        categoryRepository.save(all.get(0));
         System.out.println("all = " + all);
 

--- a/src/test/java/SilkLoad/repository/CrawlingRepositoryTest.java
+++ b/src/test/java/SilkLoad/repository/CrawlingRepositoryTest.java
@@ -37,7 +37,7 @@ class CrawlingRepositoryTest {
         PageRequest pageRequest = PageRequest.of(1, 8);
 
         Page<CrawlingDto> data = crawlingRepository
-                .findByFirstAndSecondAndThird("여성의류", "코트", "봄가을", pageRequest)
+                .findByFirstAndSecondAndThirdContains("여성의류", "청바지", "기타(청바지)", pageRequest)
                 .map(this::ToCrawlingDto);
         System.out.println("data = " + data.getContent());
 


### PR DESCRIPTION
## 📌Linked Issues

- 

## ✏Change Details

- 기존 쿼리문의 where first = ? , second = ?, third = ? 로 구성을 where first = ? , second = ?, third like %?% 형태로 바꿈
- detailPage.html의  설명문의 줄바꿈 코드 넣음

## 💬Comment

- **### 물품 등록시 문제**
- 1,2,3차 카테고리를 where 그래도 넣으면 category 테이블에 세로운 1,2,3차 카테고리가 생김
- ex) 디지털/가전, 모바일, 웨어러블 << 이상태로 넣으면 새로 생김
-       디지털/가전, 모바일, 웨어러블(워치) << 여기에 들가는 것을 원했다.
- 그래서 LIKE 문을 줘서 %웨어러블 % 을 가진 모든 것에 들어가게끔 했다.

**### 크롤링 물품 가져올때 문제**
- 기타() 이것도 해결되었다.
- 크롤링 테이블에는 기타(~~) 를 보면 ()안에 카테고리가 따로 들어가 있음
- 원래는 **쿼리스트링**을 모두 고쳐줘야 하지만 
- LIKE 문을 줘서 3차 카테고리에 기타 있는건 모조리 다 가져오는 것으로 변경

## 📑References

- https://recordsoflife.tistory.com/59

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?

