### PR TITLE
aws에서 shop.html 에러 해결

### DIFF
--- a/src/main/java/SilkLoad/controller/Member/MyPageController.java
+++ b/src/main/java/SilkLoad/controller/Member/MyPageController.java
@@ -114,7 +114,7 @@ public class MyPageController {
         model.addAttribute("saleOrders", saleOrders);
         model.addAttribute("orderType", OrderType.values() );
 
-        return "/myPage/memberSaleOrders";
+        return "myPage/memberSaleOrders";
     }
 
     @GetMapping("/purchaseOrders")
@@ -124,7 +124,7 @@ public class MyPageController {
         Page<OrderHistoryDto> purchaseOrders = orderService.findMemberPurchaseOrder(sessionMembers.getId(), pageable);
 
         calculationDeadLine(purchaseOrders);
-        
+
         int totalPages = purchaseOrders.getTotalPages(); //전체 페이지 수
         int presentPage = purchaseOrders.getNumber(); //현재 페이지
         model.addAttribute("totalPages",totalPages); //전체 페이지  모델로 보내기
@@ -133,7 +133,7 @@ public class MyPageController {
         model.addAttribute("purchaseOrders", purchaseOrders);
         model.addAttribute("orderType", OrderType.values());
 
-        return "/myPage/memberPurchaseOrders";
+        return "myPage/memberPurchaseOrders";
 
     }
 
@@ -151,7 +151,7 @@ public class MyPageController {
         model.addAttribute("totalPages",totalPages); //전체 페이지  모델로 보내기
         model.addAttribute("presentPage",presentPage); //현재 페이지  모델로 보내기
 
-        return "/myPage/memberChatRoomList";
+        return "myPage/memberChatRoomList";
     }
 
     @GetMapping("/room/{roomId}")
@@ -161,7 +161,7 @@ public class MyPageController {
         Members sessionMembers = getSessionMembers(request);
         Long memberId = sessionMembers.getId();
         if (!chatService.checkRoomPermission(roomId, memberId) ) {
-            return "redirect:/members/myPage/myChatRoomList";
+            return "redirect:members/myPage/myChatRoomList";
         }
 
         ChatRoomDto chatRoomDto = chatService.getChatRoom(roomId);
@@ -172,7 +172,7 @@ public class MyPageController {
         model.addAttribute("chatRoomDto", chatRoomDto);
         model.addAttribute( "chatMessageList", chatMessageList);
 
-        return "/myPage/memberChatRoom";
+        return "myPage/memberChatRoom";
 
     }
 
@@ -191,7 +191,7 @@ public class MyPageController {
 
         redirectAttributes.addAttribute("roomId", roomId);
 
-        return "redirect:/members/myPage/room/{roomId}";
+        return "redirect:members/myPage/room/{roomId}";
     }
 
     private void calculationDeadLine(Page<OrderHistoryDto> tradeOrders) {

--- a/src/main/java/SilkLoad/controller/Shop/ShopController.java
+++ b/src/main/java/SilkLoad/controller/Shop/ShopController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @Slf4j
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/shop")
+@RequestMapping("shop")
 public class ShopController {
 
     private final ProductService productService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,7 +17,7 @@ spring.jpa.hibernate.ddl-auto=none
 
 # sql setting
 spring.jpa.open-in-view=false
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
@@ -25,10 +25,13 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 
-# upload location
-
-imgFile.dir=C:/Users/0320k/my_coding/IdeaProjects/Spring/schoolProject/CD_Back/file/
+#imgFile.dir=C:/Users/0320k/my_coding/IdeaProjects/Spring/schoolProject/CD_Back/file/
 #imgFile.dir=E:/SilkLoad/file/
+imgFile.dir=/home/ubuntu/img/
+
+#spring thymleaf path check
+spring.thymeleaf.prefix=classpath:/templates/
+
 
 # http request message check
 #logging.level.org.apache.coyote.http11=debug

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{/layoutFile :: layout(~{::body}, 'error')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile :: layout(~{::body}, 'error')}">
 <!-- Body-->
 <body class="handheld-toolbar-enabled">
 

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html th:fragment="layout (content, paramActive)" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:fragment="layout(content, paramActive)" >
 <head>
     <meta charset="utf-8">
     <title>Silk Load</title>

--- a/src/main/resources/templates/myPage/memberChatRoom.html
+++ b/src/main/resources/templates/myPage/memberChatRoom.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile::layout(~{::body},'myPage')}">
 
 <!-- Body-->
 <body class="handheld-toolbar-enabled">

--- a/src/main/resources/templates/myPage/memberChatRoomList.html
+++ b/src/main/resources/templates/myPage/memberChatRoomList.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile::layout(~{::body},'myPage')}">
 
 <!-- Body-->
 <body class="handheld-toolbar-enabled">
@@ -28,7 +26,7 @@
     <div class="container pb-5 mb-2 mb-md-4">
         <div class="row">
             <!-- Sidebar-->
-            <div th:replace="~{myPage/myPageSidebar:: sidebar ('myChatRoomList')}"></div>
+            <div th:replace="~{myPage/myPageSidebar::sidebar('myChatRoomList')}"></div>
             <!-- Content  -->
             <section class="col-lg-8">
                 <div class="d-flex justify-content-between align-items-center pt-lg-2 pb-4 pb-lg-5 mb-lg-3">

--- a/src/main/resources/templates/myPage/memberProfile.html
+++ b/src/main/resources/templates/myPage/memberProfile.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
 
 <!-- Body-->
 <body class="handheld-toolbar-enabled">

--- a/src/main/resources/templates/myPage/memberPurchaseOrders.html
+++ b/src/main/resources/templates/myPage/memberPurchaseOrders.html
@@ -1,9 +1,5 @@
-
-
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile::layout(~{::body},'myPage')}">
 
 <!-- Body-->
 <body class="handheld-toolbar-enabled">
@@ -32,7 +28,7 @@
     <div class="container pb-5 mb-2 mb-md-4">
         <div class="row">
             <!-- Sidebar-->
-            <div th:replace="~{myPage/myPageSidebar:: sidebar ('purchaseOrders')}"></div>
+            <div th:replace="~{myPage/myPageSidebar::sidebar('purchaseOrders')}"></div>
             <!-- Content  -->
             <section class="col-lg-8">
                 <!-- Toolbar-->

--- a/src/main/resources/templates/myPage/memberSaleOrders.html
+++ b/src/main/resources/templates/myPage/memberSaleOrders.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+
 
 <!-- Body-->
 <body class="handheld-toolbar-enabled">
@@ -29,7 +28,7 @@
 <div class="container pb-5 mb-2 mb-md-4">
     <div class="row">
         <!-- Sidebar-->
-        <div th:replace="~{myPage/myPageSidebar:: sidebar ('saleOrders')}"></div>
+        <div th:replace="~{myPage/myPageSidebar:: sidebar('saleOrders')}"></div>
         <!-- Content  -->
         <section class="col-lg-8">
             <!-- Toolbar-->

--- a/src/main/resources/templates/myPage/memberWishlist.html
+++ b/src/main/resources/templates/myPage/memberWishlist.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile :: layout(~{::body},'myPage')}">
 
 <!-- Body-->
 <body class="handheld-toolbar-enabled">
@@ -30,7 +28,7 @@
         <div class="row">
 
             <!-- Sidebar-->
-            <div th:replace="~{myPage/myPageSidebar:: sidebar ('wishlist')}"></div>
+            <div th:replace="~{myPage/myPageSidebar:: sidebar('wishlist')}"></div>
             <!-- Content  -->
             <section class="col-lg-8">
 

--- a/src/main/resources/templates/myPage/myPageSidebar.html
+++ b/src/main/resources/templates/myPage/myPageSidebar.html
@@ -1,5 +1,5 @@
 <html xmlns:th="http://www.thymeleaf.org">
-<aside class="col-lg-4 pt-4 pt-lg-0 pe-xl-5" th:fragment="sidebar (paramActive)">
+<aside class="col-lg-4 pt-4 pt-lg-0 pe-xl-5" th:fragment="sidebar(paramActive)">
     <div class="bg-white rounded-3 shadow-lg pt-1 mb-5 mb-lg-0">
 
         <div class="d-md-flex justify-content-between align-items-center text-center text-md-start p-4">

--- a/src/main/resources/templates/shop-cart.html
+++ b/src/main/resources/templates/shop-cart.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body}, 'shop-cart')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile :: layout(~{::body}, 'shop-cart')}">
 
   <!-- Body-->
   <body class="handheld-toolbar-enabled">

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
-      xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layoutFile :: layout(~{::body}, 'shop')}">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layoutFile::layout(~{::body},'shop')}">
 <!-- Body-->
 <body class="handheld-toolbar-enabled">
     <!-- Page Title-->
@@ -26,7 +24,7 @@
         <div class="row">
 
             <!-- Sidebar-->
-            <div th:replace="~{/shopSidebar:: sidebar ('shopSidebar')}"></div>
+            <div th:replace="~{shopSidebar:: sidebar('shopSidebar')}"></div>
             <!-- Content  -->
             <section class="col-lg-8">
                 <!-- Toolbar-->

--- a/src/main/resources/templates/shopSidebar.html
+++ b/src/main/resources/templates/shopSidebar.html
@@ -1,5 +1,5 @@
 <html xmlns:th="http://www.thymeleaf.org">
-<aside class="col-lg-3" th:fragment="sidebar (paramActive)">
+<aside class="col-lg-3" th:fragment="sidebar(paramActive)">
     <!-- Sidebar-->
     <div class="offcanvas offcanvas-collapse bg-white w-100 rounded-3 shadow-lg py-1" id="shop-sidebar"
          style="max-width: 22rem;">


### PR DESCRIPTION
## 📌Linked Issues

- https://wonin.tistory.com/503

## ✏Change Details

- thymleaf 문법 사용시 layout, fragement 형태의 html 문법은 1줄로 작성
- application.properties 에서 show-sql=false로 변경해서 쿼리문 안나오게 변경
- thymeleaf의 메인 경로를 /templates/ 아래로 변경(이유는 아래 Comment에서)
- img 경로를 ec2의 /home/ubuntu/img/ 폴더 아래로 변경

## 💬Comment

- 리눅스에서 thymeleaf 문법을 사용할 때 "=" 기호가 나타나면 왠만하면 붙혀주는게 좋다.(이유는 References)
- ec2(리눅스) 환경에서 thymeleaf의 경로가 문제가 되었다.
- layout 폴더를 곧이 곧대로 /layout/~~~~ 하면 리눅스가 진짜로 루트폴더 부터 찾아서 에러가 발생했었음
- Controller에서 반환값이 "/member/~~~~~"로 시작하는 것도 같은 에러를 발생시킴 "member/~~~~~"로 바꿈


- ec2 접근하는 AMI(?), IAM(?)은 좀더 공부해봐야 할듯


## 📑References

- https://awse2050.tistory.com/58   (쉘스크립트 적을 떄 문제)

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?