### PR TITLE
index 페이지 번개장터, 네이버쇼핑몰 나오는 부분 row 형태로

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@
 
 ## 🍀 폴더구조
 
-| 위치                      | 설명                                 |
-| ------------------------- | ------------------------------------ |
-| src/main/demo/controller  | 컨트롤러 처리하는 곳                 |
-| src/main/demo/config      | WebConfig, Interceptor 페이지를 관리 |
-| src/main/demo/dto         | 데이터 오브젝트로 받는 곳            |
-| src/main/demo/entity      | mysql table이 있는 곳                |
-| src/main/demo/interceptor | interceptor 상새 설정                |
-| src/main/demo/repository  | JPA문 쓰는 곳                        |
-| src/main/demo/service     | DB에서 넘어온 데이터를 가공하는 곳   |
+| 위치                          | 설명                                                        |
+| ----------------------------- | ----------------------------------------------------------- |
+| src/main/SilkLoad/config      | db설정, 소켓 통신 설정 하는 곳                              |
+| src/main/SilkLoad/controller  | 컨트롤러 처리하는 곳                                        |
+| src/main/SilkLoad/config      | WebConfig, Interceptor 페이지, 소켓 통신 설정을 관리        |
+| src/main/SilkLoad/dto         | 데이터 오브젝트로 받는 곳                                   |
+| src/main/SilkLoad/entity      | mysql table이 있는 곳                                       |
+| src/main/SilkLoad/interceptor | interceptor 상새 설정                                       |
+| src/main/SilkLoad/repository  | JPA문 쓰는 곳                                               |
+| src/main/SilkLoad/service     | DB에서 넘어온 데이터를 가공하는 곳, 비지니스 로직이 있는 곳 |
 
 
 

--- a/crawling/crawling_bunjang.py
+++ b/crawling/crawling_bunjang.py
@@ -159,7 +159,8 @@ def crawling(category_list):
             i += 1
 
     connect = pymysql.connect(
-        host='localhost', user='root', password='1234', db='silkLoad', charset='utf8mb4')
+        host='my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com', user='admin', password='alsgh0217',
+        db='silkload', charset='utf8mb4')
     cursor = connect.cursor()
 
     # delete = """delete from crawling where exists(select * from crawling)"""
@@ -189,7 +190,8 @@ def crawling(category_list):
 
 def db_reset():
     connect = pymysql.connect(
-        host='localhost', user='root', password='1234', db='silkload', charset='utf8mb4')
+        host='my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com', user='admin', password='alsgh0217',
+        db='silkload', charset='utf8mb4')
     cursor = connect.cursor()
 
     # delete = """delete from crawling"""

--- a/src/main/java/SilkLoad/entity/Product.java
+++ b/src/main/java/SilkLoad/entity/Product.java
@@ -4,8 +4,6 @@ package SilkLoad.entity;
 import SilkLoad.entity.ProductEnum.ProductTime;
 import SilkLoad.entity.ProductEnum.ProductType;
 import lombok.*;
-import org.aspectj.weaver.ast.Or;
-import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -29,7 +27,7 @@ public class Product {
     private Long instantPrice; //즉시거래가격
     private String explanation; //물품상세설명
 
-    private String predictionImage;
+    private String predictionName; //예측 이미지 이름
 
     @Enumerated(EnumType.STRING)
     private ProductType productType;
@@ -83,7 +81,7 @@ public class Product {
         this.auctionPrice = auctionPrice;
         this.instantPrice = instantPrice;
         this.explanation = explanation;
-        this.predictionImage = predictionImage;
+        this.predictionName = predictionImage;
         this.createdDate = createdDate;
         this.productType = productType;
         this.members = members;

--- a/src/main/java/SilkLoad/service/NaverProductService.java
+++ b/src/main/java/SilkLoad/service/NaverProductService.java
@@ -32,7 +32,6 @@ public class NaverProductService {
                 .encode()
                 .build()
                 .toUri();
-        log.info("uri : {}", uri);
 
         RestTemplate restTemplate = new RestTemplate();
         RequestEntity<Void> req = RequestEntity
@@ -49,7 +48,6 @@ public class NaverProductService {
         ResponseEntity<String> result = restTemplate.exchange(req, String.class);
         List<NaverProductDto> naverProductDtos = fromJSONtoNaverProduct(result.getBody());
 
-        log.info("result ={}", naverProductDtos);
         return naverProductDtos;
 
     }

--- a/src/main/java/SilkLoad/service/ProductService.java
+++ b/src/main/java/SilkLoad/service/ProductService.java
@@ -220,7 +220,7 @@ public class ProductService {
                 .auctionPrice(product.getAuctionPrice())
                 .instantPrice(product.getInstantPrice())
                 .explanation(product.getExplanation())
-                .predictionImage(product.getPredictionImage())
+                .predictionImage(product.getPredictionName())
                 .productType(product.getProductType())
                 .categoryRecordDto(CategoryToDto(product.getCategory()))
                 .deadLine(productDeadLine(product.getCreatedDate(), product.getProductTime()))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 # mysql ?? (Data Source)
 spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
-#spring.datasource.hikari.jdbc-url=jdbc:mysql://my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com:3306/silkload?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
-spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.hikari.jdbc-url=jdbc:mysql://my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com:3306/silkload?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+#spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
 
 
-spring.datasource.hikari.username=root
+spring.datasource.hikari.username=admin
 #admin
-spring.datasource.hikari.password=1234
+spring.datasource.hikari.password=alsgh0217
 #alsgh0217
 
 # Resource and Thymeleaf Refresh
@@ -30,9 +30,9 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 
-imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
+#imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
 #imgFile.dir=E:/SilkLoad/file/
-#imgFile.dir=/home/ubuntu/img/
+imgFile.dir=/home/ubuntu/img/
 
 #spring thymleaf path check
 spring.thymeleaf.prefix=classpath:/templates/

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -78,7 +78,7 @@
 
         <section class="container mb-5 mt-2 row" >
             <!-- 번개장터에서 가저온 물품-->
-            <section class=" mb-5 mt-2 col-md-6">
+            <section class="border border-3 mb-5 mt-2 col-md-6">
                 <h3 class="mb-4">번개장터</h3>
                 <div class="tns-carousel border-end">
                     <div class="tns-carousel-inner"
@@ -86,8 +86,8 @@
 &quot;autoplay&quot;: true, &quot;autoplayTimeout&quot;: 4000,
 &quot;loop&quot;: true,
 &quot;responsive&quot;: {&quot;0&quot;:{&quot;items&quot;:1},
-&quot;360&quot;:{&quot;items&quot;:2},&quot;600&quot;:{&quot;items&quot;:2},
-&quot;991&quot;:{&quot;items&quot;:3},&quot;1200&quot;:{&quot;items&quot;:3}} }">
+&quot;360&quot;:{&quot;items&quot;:1},&quot;600&quot;:{&quot;items&quot;:1},
+&quot;991&quot;:{&quot;items&quot;:2},&quot;1200&quot;:{&quot;items&quot;:2}} }">
                         <div>
                             <div class="widget">
                                 <h3 class="widget-title">여성의류</h3>
@@ -340,7 +340,7 @@
 
             </section>
             <!-- 네이버에서 가저온 물품-->
-            <section class=" mb-5 mt-2 col-md-6">
+            <section class="border border-3 mb-5 mt-2 col-md-6">
                 <h3 class="mb-4">네이버 쇼핑몰</h3>
                 <div class="tns-carousel border-end">
                     <div class="tns-carousel-inner"
@@ -348,8 +348,8 @@
 &quot;autoplay&quot;: true, &quot;autoplayTimeout&quot;: 4000,
 &quot;loop&quot;: true,
 &quot;responsive&quot;: {&quot;0&quot;:{&quot;items&quot;:1},
-&quot;360&quot;:{&quot;items&quot;:2},&quot;600&quot;:{&quot;items&quot;:2},
-&quot;991&quot;:{&quot;items&quot;:3},&quot;1200&quot;:{&quot;items&quot;:3}} }">
+&quot;360&quot;:{&quot;items&quot;:1},&quot;600&quot;:{&quot;items&quot;:1},
+&quot;991&quot;:{&quot;items&quot;:2},&quot;1200&quot;:{&quot;items&quot;:2}} }">
                         <div>
                             <div class="widget">
                                 <h3 class="widget-title">여성의류</h3>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -75,541 +75,417 @@
                 <hr class="d-sm-none">
             </div>
         </div>
-    </section>
 
-
-    <section class="container mb-5 mt-2">
-        <h3 class="mb-4">번개장터</h3>
-        <div class="tns-carousel border-end">
-            <div class="tns-carousel-inner"
-                 data-carousel-options="{ &quot;nav&quot;: false, &quot;controls&quot;: false,
+        <section class="container mb-5 mt-2 row" >
+            <!-- 번개장터에서 가저온 물품-->
+            <section class=" mb-5 mt-2 col-md-6">
+                <h3 class="mb-4">번개장터</h3>
+                <div class="tns-carousel border-end">
+                    <div class="tns-carousel-inner"
+                         data-carousel-options="{ &quot;nav&quot;: false, &quot;controls&quot;: false,
 &quot;autoplay&quot;: true, &quot;autoplayTimeout&quot;: 4000,
 &quot;loop&quot;: true,
 &quot;responsive&quot;: {&quot;0&quot;:{&quot;items&quot;:1},
-&quot;360&quot;:{&quot;items&quot;:2},&quot;600&quot;:{&quot;items&quot;:3},
-&quot;991&quot;:{&quot;items&quot;:4},&quot;1200&quot;:{&quot;items&quot;:4}} }">
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">여성의류</h3>
+&quot;360&quot;:{&quot;items&quot;:2},&quot;600&quot;:{&quot;items&quot;:2},
+&quot;991&quot;:{&quot;items&quot;:3},&quot;1200&quot;:{&quot;items&quot;:3}} }">
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">여성의류</h3>
 
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${women_close}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${women_close}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">남성의류</h3>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">남성의류</h3>
 
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${men_close}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${men_close}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
                                 </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">패션잡화</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${shose}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">스포츠/레저</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${sport}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">차량/오토바이</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${car}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">스타굿즈</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${star}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">키덜트</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${toy}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">예술/희귀/수집품</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${art}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">도서/티켓/문구/음악</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${book}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">가구/인테리어</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${family}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">생활/가공식품</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${life}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">유아동/출산</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${kid}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">반려동물용품</h3>
+
+                                <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${animal}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
+                                        <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getPrice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
                             </div>
                         </div>
 
                     </div>
                 </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">패션잡화</h3>
 
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${shose}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">스포츠/레저</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${sport}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">차량/오토바이</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${car}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">스타굿즈</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${star}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">키덜트</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${toy}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">예술/희귀/수집품</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${art}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">도서/티켓/문구/음악</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${book}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">가구/인테리어</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${family}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">생활/가공식품</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${life}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">유아동/출산</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${kid}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">반려동물용품</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom" th:each="product : ${animal}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink()}">
-                                <img th:src="${product.getImg_link()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:text="${product.getName()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getPrice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    </section>
-    <!-- 네이버에서 가저온 물품-->
-    <section class="container mb-5 mt-2">
-        <h3 class="mb-4">네이버 쇼핑몰</h3>
-        <div class="tns-carousel border-end">
-            <div class="tns-carousel-inner"
-                 data-carousel-options="{ &quot;nav&quot;: false, &quot;controls&quot;: false,
+            </section>
+            <!-- 네이버에서 가저온 물품-->
+            <section class=" mb-5 mt-2 col-md-6">
+                <h3 class="mb-4">네이버 쇼핑몰</h3>
+                <div class="tns-carousel border-end">
+                    <div class="tns-carousel-inner"
+                         data-carousel-options="{ &quot;nav&quot;: false, &quot;controls&quot;: false,
 &quot;autoplay&quot;: true, &quot;autoplayTimeout&quot;: 4000,
 &quot;loop&quot;: true,
 &quot;responsive&quot;: {&quot;0&quot;:{&quot;items&quot;:1},
-&quot;360&quot;:{&quot;items&quot;:2},&quot;600&quot;:{&quot;items&quot;:3},
-&quot;991&quot;:{&quot;items&quot;:4},&quot;1200&quot;:{&quot;items&quot;:4}} }">
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">여성의류</h3>
+&quot;360&quot;:{&quot;items&quot;:2},&quot;600&quot;:{&quot;items&quot;:2},
+&quot;991&quot;:{&quot;items&quot;:3},&quot;1200&quot;:{&quot;items&quot;:3}} }">
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">여성의류</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${womenClothingList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">남성의류</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${menClothingList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
 
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${womenClothingList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">신발</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${shoesList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">스포츠/레저</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${sportsList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">차량/오토바이</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${vehicleList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">스타굿즈</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${starGoodsList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="widget">
+                                <h3 class="widget-title">키덜트</h3>
+                                <div class="d-flex align-items-center pb-2 border-bottom"
+                                     th:each="product : ${kidultList}">
+                                    <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
+                                        <img th:src="${product.getImage()}" width="64" alt="Product"></a>
+                                    <div class="ps-2">
+                                        <h6 class="widget-product-title">
+                                            <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
+                                        </h6>
+                                        <div class="widget-product-meta">
+                                            <span class="text-accent" th:text="${product.getLprice()}">가격</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">남성의류</h3>
-
-
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${menClothingList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">신발</h3>
-
-
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${shoesList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">스포츠/레저</h3>
-
-
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${sportsList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">차량/오토바이</h3>
-
-
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${vehicleList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">스타굿즈</h3>
-
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${starGoodsList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div>
-                    <div class="widget">
-                        <h3 class="widget-title">키덜트</h3>
-
-
-                        <div class="d-flex align-items-center pb-2 border-bottom"
-                             th:each="product : ${kidultList}">
-                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">
-                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>
-                            <div class="ps-2">
-                                <h6 class="widget-product-title">
-                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>
-                                </h6>
-                                <div class="widget-product-meta">
-                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-<!--                <div>-->
-<!--                    <div class="widget">-->
-<!--                        <h3 class="widget-title">예술/희귀/수집품</h3>-->
-
-<!--                        <div class="d-flex align-items-center pb-2 border-bottom"-->
-<!--                             th:each="product : ${artList}">-->
-<!--                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">-->
-<!--                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>-->
-<!--                            <div class="ps-2">-->
-<!--                                <h6 class="widget-product-title">-->
-<!--                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>-->
-<!--                                </h6>-->
-<!--                                <div class="widget-product-meta">-->
-<!--                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div>-->
-<!--                    <div class="widget">-->
-<!--                        <h3 class="widget-title">도서/티켓/문구/음악</h3>-->
-
-<!--                        <div class="d-flex align-items-center pb-2 border-bottom"-->
-<!--                             th:each="product : ${bookList}">-->
-<!--                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">-->
-<!--                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>-->
-<!--                            <div class="ps-2">-->
-<!--                                <h6 class="widget-product-title">-->
-<!--                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>-->
-<!--                                </h6>-->
-<!--                                <div class="widget-product-meta">-->
-<!--                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div>-->
-<!--                    <div class="widget">-->
-<!--                        <h3 class="widget-title">가구/인테리어</h3>-->
-
-<!--                        <div class="d-flex align-items-center pb-2 border-bottom"-->
-<!--                             th:each="product : ${furnitureList}">-->
-<!--                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">-->
-<!--                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>-->
-<!--                            <div class="ps-2">-->
-<!--                                <h6 class="widget-product-title">-->
-<!--                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>-->
-<!--                                </h6>-->
-<!--                                <div class="widget-product-meta">-->
-<!--                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div>-->
-<!--                    <div class="widget">-->
-<!--                        <h3 class="widget-title">생활/가공식품</h3>-->
-
-<!--                        <div class="d-flex align-items-center pb-2 border-bottom"-->
-<!--                             th:each="product : ${processedFoodList}">-->
-<!--                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">-->
-<!--                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>-->
-<!--                            <div class="ps-2">-->
-<!--                                <h6 class="widget-product-title">-->
-<!--                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>-->
-<!--                                </h6>-->
-<!--                                <div class="widget-product-meta">-->
-<!--                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div>-->
-<!--                    <div class="widget">-->
-<!--                        <h3 class="widget-title">유아동/출산</h3>-->
-
-
-<!--                        <div class="d-flex align-items-center pb-2 border-bottom"-->
-<!--                             th:each="product : ${infantChildList}">-->
-<!--                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">-->
-<!--                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>-->
-<!--                            <div class="ps-2">-->
-<!--                                <h6 class="widget-product-title">-->
-<!--                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>-->
-<!--                                </h6>-->
-<!--                                <div class="widget-product-meta">-->
-<!--                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div>-->
-<!--                    <div class="widget">-->
-<!--                        <h3 class="widget-title">반려동물용품</h3>-->
-
-<!--                        <div class="d-flex align-items-center pb-2 border-bottom"-->
-<!--                             th:each="product : ${petList}">-->
-<!--                            <a class="d-block flex-shrink-0" th:href="${product.getLink() }">-->
-<!--                                <img th:src="${product.getImage()}" width="64" alt="Product"></a>-->
-<!--                            <div class="ps-2">-->
-<!--                                <h6 class="widget-product-title">-->
-<!--                                    <a th:href="${product.getLink()}" th:utext="${product.getTitle()}">물품 이름</a>-->
-<!--                                </h6>-->
-<!--                                <div class="widget-product-meta">-->
-<!--                                    <span class="text-accent" th:text="${product.getLprice()}">가격</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-
-<!--                    </div>-->
-<!--                </div>-->
-
-            </div>
-        </div>
+            </section>
+        </section>
     </section>
+
+
+
 </main>
 
 <script th:inline="javascript">

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -36,7 +36,7 @@
     <div class="navbar-sticky bg-light">
         <div class="navbar navbar-expand-lg navbar-light">
             <div class="container">
-                <a class="navbar-brand d-none d-sm-block flex-shrink-0" href="/">
+                <a class="navbar-brand d-sm-block flex-shrink-0" href="/">
                     SilkLoad
                 </a>
 
@@ -45,8 +45,6 @@
                         <input class="form-control rounded-end pe-5" type="text" placeholder="Search for products"
                         th:name="keyword" th:value="${keyword}">
                     </form>
-
-
                 </div>
 
                 <div class="navbar-toolbar d-flex flex-shrink-0 align-items-center">


### PR DESCRIPTION
## 📌Linked Issues

- 

## ✏Change Details

- index 페이지 번개장터, 네이버 쇼핑몰 물품 가져오는 것 3줄로 바꿈
- row형태로 한눈에 볼 수 있음

## 💬Comment

- 상품 제목이 길면 꽉 막혀있는 느낌이 들 수 있음
- 그러면 물품 슬라이더를 2줄로 바꾸는 것도 고려해볼 수 있음

## 📑References

- 

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?