### PR TITLE
OAuth2 테스트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ out/
 .vscode/
 
 file/
-
+application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.projectlombok:lombok:1.18.18'
 	implementation 'org.json:json:20211205'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/SilkLoad/config/WebConfig.java
+++ b/src/main/java/SilkLoad/config/WebConfig.java
@@ -10,33 +10,33 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-
-        //에러 페이지 처리
-        registry.addInterceptor(new ErrorPageCheckInterceptor())
-                .order(0)
-                .addPathPatterns("/**")
-                .excludePathPatterns("/",
-                        "/members/add","/members/myPage/profile","/members/myPage/wishlist","/members/myPage/saleOrders",
-                        "/members/myPage/purchaseOrders","/product/order/transaction/**", "/members/myPage/myChatRoomList",
-                        "/members/myPage/room/**",
-                        "/login", "/logout","/home",
-                        "/product/add","/product/order/buyNow","/product/order/inCart","/product/images/**","/product/order/buyAuction",
-                       "/product/order/deleteCart",
-                        "/Cart","/myPage",
-                        "/shop/**",
-                        "/css/**", "/*.ico", "/error","/vendor/**", "/img/**","/js/**","/fonts/**" );
-
-        //로그인 인증
-        registry.addInterceptor(new LoginCheckInterceptor())
-                .order(1)
-                .addPathPatterns("/**")
-                .excludePathPatterns(
-                        "/", "/members/add", "/login", "/logout","/home","/product/images/**","/shop/**",
-                        "/css/**", "/*.ico", "/error","/vendor/**", "/img/**","/js/**","/fonts/**"
-                );
-
-          }
+//    @Override
+//    public void addInterceptors(InterceptorRegistry registry) {
+//
+////        //에러 페이지 처리
+//        registry.addInterceptor(new ErrorPageCheckInterceptor())
+//                .order(0)
+//                .addPathPatterns("/**")
+//                .excludePathPatterns("/",
+//                        "/members/add", "/members/myPage/profile", "/members/myPage/wishlist", "/members/myPage/saleOrders",
+//                        "/members/myPage/purchaseOrders", "/product/order/transaction/**", "/members/myPage/myChatRoomList",
+//                        "/members/myPage/room/**",
+//                        "/login", "/logout", "/home",
+//                        "/product/add", "/product/order/buyNow", "/product/order/inCart", "/product/images/**", "/product/order/buyAuction",
+//                        "/product/order/deleteCart",
+//                        "/Cart", "/myPage",
+//                        "/shop/**",
+//                        "/css/**", "/*.ico", "/error", "/vendor/**", "/img/**", "/js/**", "/fonts/**");
+//
+//        //로그인 인증
+//        registry.addInterceptor(new LoginCheckInterceptor())
+//                .order(1)
+//                .addPathPatterns("/**")
+//                .excludePathPatterns(
+//                        "/", "/members/add", "/login", "/logout", "/home", "/product/images/**", "/shop/**",
+//                        "/css/**", "/*.ico", "/error", "/vendor/**", "/img/**", "/js/**", "/fonts/**"
+//                );
+//
+//    }
 
 }

--- a/src/main/java/SilkLoad/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/SilkLoad/config/auth/CustomOAuth2UserService.java
@@ -1,0 +1,56 @@
+package SilkLoad.config.auth;
+
+import SilkLoad.config.auth.dto.OAuthAttributes;
+import SilkLoad.config.auth.dto.SessionUser;
+import SilkLoad.entity.User;
+import SilkLoad.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        log.info("getAttrigute : {}", oAuth2User.getAttributes());
+        // OAuth2 서비스 id (구글, 카카오, 네이버)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        // OAuth2 로그인 진행 시 키가 되는 필드 값(PK)
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // OAuth2UserService
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+        User user = saveOrUpdate(attributes);
+        httpSession.setAttribute("user", new SessionUser(user)); // SessionUser (직렬화된 dto 클래스 사용)
+
+        return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+
+    // 유저 생성 및 수정 서비스 로직
+    private User saveOrUpdate(OAuthAttributes attributes){
+        log.info("attributes 들어옴 : {}", attributes);
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.toEntity());
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/SilkLoad/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/SilkLoad/config/auth/CustomOAuth2UserService.java
@@ -2,8 +2,11 @@ package SilkLoad.config.auth;
 
 import SilkLoad.config.auth.dto.OAuthAttributes;
 import SilkLoad.config.auth.dto.SessionUser;
+import SilkLoad.entity.Members;
 import SilkLoad.entity.User;
+import SilkLoad.repository.MemberRepository;
 import SilkLoad.repository.UserRepository;
+import SilkLoad.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -24,6 +27,7 @@ import java.util.Collections;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     private final UserRepository userRepository;
     private final HttpSession httpSession;
+    private final MemberRepository memberRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -51,6 +55,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         User user = userRepository.findByEmail(attributes.getEmail())
                 .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
                 .orElse(attributes.toEntity());
+        log.info("attributes 들어옴 : {}", attributes.getEmail());
+        Members members = memberRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.CreateMemberEntity());
+        memberRepository.save(members);
+
         return userRepository.save(user);
     }
 }

--- a/src/main/java/SilkLoad/config/auth/SecurityConfig.java
+++ b/src/main/java/SilkLoad/config/auth/SecurityConfig.java
@@ -23,13 +23,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+
         http
                 .csrf()
                 .and()
                 .authorizeRequests()
                 .antMatchers("/", "/css/**","/fonts/**","/img/**","/vendor/**", "/js/**").permitAll() // 허용 파일 범위
                 .antMatchers("/shop/**").permitAll()
-                .antMatchers("/product/add").hasRole(Role.USER.name()) // username이 있는 사용자만 들어갈 수 있따.
+                .antMatchers("/product/**").hasRole(Role.GUEST.name()) // guest 사용자만 들어갈 수 있따. 들어온 String 뒤에 자동으로 _ROLE 붙여준다.
+                .antMatchers("/members/**").hasRole(Role.GUEST.name()) // username이 있는 사용자만 들어갈 수 있따.
                 .anyRequest()
                 .authenticated()
                 .and()

--- a/src/main/java/SilkLoad/config/auth/SecurityConfig.java
+++ b/src/main/java/SilkLoad/config/auth/SecurityConfig.java
@@ -1,0 +1,44 @@
+package SilkLoad.config.auth;
+
+import SilkLoad.entity.UserRoleEnum.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@EnableWebSecurity // Spring Security 설정 활성화
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf()
+                .and()
+                .authorizeRequests()
+                .antMatchers("/", "/css/**","/fonts/**","/img/**","/vendor/**", "/js/**").permitAll() // 허용 파일 범위
+                .antMatchers("/shop/**").permitAll()
+                .antMatchers("/product/add").hasRole(Role.USER.name()) // username이 있는 사용자만 들어갈 수 있따.
+                .anyRequest()
+                .authenticated()
+                .and()
+                    .logout()
+                        .logoutSuccessUrl("/")//로그아웃이 성공하면 가는 곳
+                .and()
+                    .oauth2Login()
+                        .userInfoEndpoint()
+                    .userService(customOAuth2UserService);
+    }
+
+}

--- a/src/main/java/SilkLoad/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/SilkLoad/config/auth/dto/OAuthAttributes.java
@@ -1,0 +1,53 @@
+package SilkLoad.config.auth.dto;
+
+import SilkLoad.entity.UserRoleEnum.Role;
+import SilkLoad.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+//OAuth2UserService를 통해 가져온 네이버 OAuth2User의 attributes를 담을 클래스이다.
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes; // OAuth2 반환하는 유저 정보 Map
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
+        // 여기서 네이버와 카카오 등 구분 (ofNaver, ofKakao)
+
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity(){
+        return User.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.GUEST) // 기본 권한 GUEST
+                .build();
+    }
+
+}

--- a/src/main/java/SilkLoad/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/SilkLoad/config/auth/dto/OAuthAttributes.java
@@ -1,5 +1,6 @@
 package SilkLoad.config.auth.dto;
 
+import SilkLoad.entity.Members;
 import SilkLoad.entity.UserRoleEnum.Role;
 import SilkLoad.entity.User;
 import lombok.Builder;
@@ -47,6 +48,18 @@ public class OAuthAttributes {
                 .email(email)
                 .picture(picture)
                 .role(Role.GUEST) // 기본 권한 GUEST
+                .build();
+    }
+
+    //기본적인 members 구성요소
+    public Members CreateMemberEntity(){
+        return Members.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.GUEST) // 기본 권한 GUEST
+                .ranks(1)
+                .numberPurchase(0)
                 .build();
     }
 

--- a/src/main/java/SilkLoad/config/auth/dto/SessionUser.java
+++ b/src/main/java/SilkLoad/config/auth/dto/SessionUser.java
@@ -1,0 +1,22 @@
+package SilkLoad.config.auth.dto;
+
+import SilkLoad.entity.User;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+/**
+ * 직렬화 기능을 가진 User클래스
+ */
+@Getter
+public class SessionUser implements Serializable {
+    private String name;
+    private String email;
+    private String picture;
+
+    public SessionUser(User user){
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.picture = user.getPicture();
+    }
+}

--- a/src/main/java/SilkLoad/controller/Home/HomeController.java
+++ b/src/main/java/SilkLoad/controller/Home/HomeController.java
@@ -1,6 +1,7 @@
 package SilkLoad.controller.Home;
 
 
+import SilkLoad.SessionConst;
 import SilkLoad.config.auth.dto.SessionUser;
 import SilkLoad.dto.CrawlingDto;
 import SilkLoad.dto.NaverProductDto;
@@ -8,6 +9,8 @@ import SilkLoad.dto.NaverRequestVariableDto;
 import SilkLoad.dto.ProductRecordDto;
 import SilkLoad.entity.Product;
 import SilkLoad.entity.ProductEnum.ProductType;
+import SilkLoad.entity.User;
+import SilkLoad.repository.MemberRepository;
 import SilkLoad.repository.ProductRepository;
 import SilkLoad.service.*;
 import lombok.RequiredArgsConstructor;
@@ -31,11 +34,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HomeController {
 
-    private final ProductService productService;
     private final PagedProductService pagedProductService;
     private final CrawlingService crawlingService;
-//    private final OrderService orderService;
     private final NaverProductService naverProductService;
+    private final LoginService loginService;
+
 
     /**
      * @param model product들을 담기위한 매개변수
@@ -120,10 +123,15 @@ public class HomeController {
 
         //ouath2 성공시 데이터 들어오는 곳?
         HttpSession session = request.getSession();
-        log.info("구글 로그인?");
         SessionUser user = (SessionUser) session.getAttribute("user");
-        log.info("user = {}", user);
+//        log.info("user.getName = {}", user.getName());
+//        log.info("user.gete = {}", user.getEmail());
+//        log.info("user.gept = {}", user.getPicture());
         if (user != null) {
+            //쿠키 이름: jsessionid, 값: uuid, uuid를 통해 session 속성에 접근, Member 객체를 email 기준으로 가지고옴
+            log.info("user.getName = {}", user.getName());
+            //기존 로그인 방식이랑 유사하게 하기위해 session에 email 기반의 Members 객체 데이터를 넣어둔다.
+            session.setAttribute(SessionConst.LOGIN_MEMBER, loginService.loginWithOauth2(user.getEmail()));
             model.addAttribute("userName", user.getName());
         }
 

--- a/src/main/java/SilkLoad/controller/Home/HomeController.java
+++ b/src/main/java/SilkLoad/controller/Home/HomeController.java
@@ -1,6 +1,7 @@
 package SilkLoad.controller.Home;
 
 
+import SilkLoad.config.auth.dto.SessionUser;
 import SilkLoad.dto.CrawlingDto;
 import SilkLoad.dto.NaverProductDto;
 import SilkLoad.dto.NaverRequestVariableDto;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.util.List;
 
 @Slf4j
@@ -50,7 +52,6 @@ public class HomeController {
 
         model.addAttribute("Products", content);
         model.addAttribute("sale", ProductType.sale);
-//        model.addAttribute("order", orderService);
 //------------------------번개 장터-------------------------
         Page<CrawlingDto> women_close = crawlingService.getcrawlingdatafirst(pageable, "여성의류");
         Page<CrawlingDto> men_close = crawlingService.getcrawlingdatafirst(pageable,"남성의류");
@@ -117,29 +118,14 @@ public class HomeController {
         List<NaverProductDto> kidultList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
         model.addAttribute("kidultList", kidultList);
 
-//        naverRequestVariableDto.setQuery("중고 예술");
-//        List<NaverProductDto> artList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
-//        model.addAttribute("artList", artList);
-//
-//        naverRequestVariableDto.setQuery("중고 문구 책");
-//        List<NaverProductDto> bookList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
-//        model.addAttribute("bookList", bookList);
-//
-//        naverRequestVariableDto.setQuery("중고 가구");
-//        List<NaverProductDto> furnitureList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
-//        model.addAttribute("furnitureList", furnitureList);
-//
-//        naverRequestVariableDto.setQuery("중고 가공식품");
-//        List<NaverProductDto> processedFoodList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
-//        model.addAttribute("processedFoodList", processedFoodList);
-//
-//        naverRequestVariableDto.setQuery("중고 유아동");
-//        List<NaverProductDto> infantChildList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
-//        model.addAttribute("infantChildList", infantChildList);
-//
-//        naverRequestVariableDto.setQuery("중고 반려동물");
-//        List<NaverProductDto> petList = naverProductService.naverShopSearchAPI(naverRequestVariableDto);
-//        model.addAttribute("petList", petList);
+        //ouath2 성공시 데이터 들어오는 곳?
+        HttpSession session = request.getSession();
+        log.info("구글 로그인?");
+        SessionUser user = (SessionUser) session.getAttribute("user");
+        log.info("user = {}", user);
+        if (user != null) {
+            model.addAttribute("userName", user.getName());
+        }
 
         return "index";
     }

--- a/src/main/java/SilkLoad/controller/Login/LoginController.java
+++ b/src/main/java/SilkLoad/controller/Login/LoginController.java
@@ -1,12 +1,15 @@
 package SilkLoad.controller.Login;
 
 import SilkLoad.SessionConst;
+import SilkLoad.config.auth.dto.SessionUser;
 import SilkLoad.dto.LoginFormDto;
 import SilkLoad.entity.Members;
 import SilkLoad.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -33,25 +36,28 @@ public class LoginController {
     public String login(@Valid @ModelAttribute("loginFormDto") LoginFormDto loginFormDto,
                         BindingResult bindingResult,
                         @RequestParam(defaultValue = "/") String redirectURL,
-                        HttpServletRequest request) {
-        log.info("loginFormDto : {}", loginFormDto);
-
+                        HttpServletRequest request,
+                        Model model) {
         if (bindingResult.hasErrors()) {
             return "login";
         }
         Members loginMember = loginService.login(loginFormDto.getLoginId(), loginFormDto.getPassword());
 
         if (loginMember == null) {
-
             bindingResult.reject("loginFail", "아이디 또는 비밀번호가 맞지 않습니다.");
             return "login";
-
         }
 
         HttpSession session = request.getSession();
 
         //쿠키 이름: jsessionid, 값: uuid, uuid를 통해 session 속성에 접근
         session.setAttribute(SessionConst.LOGIN_MEMBER, loginMember);
+
+        SessionUser user = (SessionUser) session.getAttribute("user");
+        log.info("user가 들어온 ={}",user);
+        if(user != null){
+            model.addAttribute("userName", user.getName());
+        }
         return "redirect:" + redirectURL;
 
     }

--- a/src/main/java/SilkLoad/controller/Login/LoginController.java
+++ b/src/main/java/SilkLoad/controller/Login/LoginController.java
@@ -53,13 +53,7 @@ public class LoginController {
         //쿠키 이름: jsessionid, 값: uuid, uuid를 통해 session 속성에 접근
         session.setAttribute(SessionConst.LOGIN_MEMBER, loginMember);
 
-        SessionUser user = (SessionUser) session.getAttribute("user");
-        log.info("user가 들어온 ={}",user);
-        if(user != null){
-            model.addAttribute("userName", user.getName());
-        }
         return "redirect:" + redirectURL;
-
     }
 
     @PostMapping("/logout")

--- a/src/main/java/SilkLoad/controller/Product/ProductController.java
+++ b/src/main/java/SilkLoad/controller/Product/ProductController.java
@@ -44,30 +44,18 @@ public class ProductController {
     public String saveProduct(@Valid @ModelAttribute("productData") ProductFormDto productData,
                               BindingResult bindingResult,
                               HttpServletRequest request) throws IOException {
-
         if (bindingResult.hasErrors()) {
             if (productData.getCategory().isEmpty()) {
                 bindingResult.reject("addCategoryFail", "카테고리 입력은 필수입니다! 3차 카테고리까지 모두 입력해주세요.");
             }
-
             else {bindingResult.reject("addProductFail", "문제가 발생했습니다! 다시 입력해주세요.");}
             return "addProductForm";
         }
 
-
-//        HttpSession session = request.getSession();
-//        Members loginMember = (Members) session.getAttribute(SessionConst.LOGIN_MEMBER);
-//        try{
-//            productService.save(productData, loginMember);
-//        }catch (DataIntegrityViolationException e){
-//
-//            return "redirect:/";
-//        }
         HttpSession session = request.getSession();
+        //session에서 login 정보를 확인하는 방식
         Members loginMember = (Members) session.getAttribute(SessionConst.LOGIN_MEMBER);
-
         productService.save(productData, loginMember);
-
         return "redirect:/";
 
     }

--- a/src/main/java/SilkLoad/entity/Members.java
+++ b/src/main/java/SilkLoad/entity/Members.java
@@ -1,7 +1,6 @@
 package SilkLoad.entity;
 
-import SilkLoad.dto.ProductFormDto;
-import SilkLoad.dto.ProductRecordDto;
+import SilkLoad.entity.UserRoleEnum.Role;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
 
@@ -16,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-@BatchSize(size=100)
+@BatchSize(size = 100)
 public class Members {
 
     @Id
@@ -27,11 +26,21 @@ public class Members {
     @Column(nullable = false, unique = true)
     private String loginId;
 
+    @Column
+    private String password;
+
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false) // OAuth2로 들어오는 정보
+    private String email;
+
+    @Column
+    private String picture; // // OAuth2로 들어오는 정보
+
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String password;
+    private Role role; // // OAuth2로 들어오는 정보
 
     private Integer ranks;
 
@@ -44,17 +53,27 @@ public class Members {
     private List<Product> productList = new ArrayList<Product>();
 
     @Builder
-    public Members(Long id, String loginId, String name, String password, Integer ranks, Integer numberPurchase) {
-
-        this.id = id;
-        this.loginId = loginId;
+    public Members(String name,
+                   String email,
+                   String picture,
+                   Role role,
+                   Integer ranks,
+                   Integer numberPurchase) {
+        this.loginId = email;
+        this.password = email;
         this.name = name;
-        this.password = password;
+        this.email = email;
+        this.picture = picture;
+        this.role = role;
         this.ranks = ranks;
         this.numberPurchase = numberPurchase;
         this.createDate = LocalDate.now();
         this.productList = new ArrayList<Product>();
-
     }
 
+    public Members update(String name, String picture) {
+        this.name = name;
+        this.picture = picture;
+        return this;
+    }
 }

--- a/src/main/java/SilkLoad/entity/User.java
+++ b/src/main/java/SilkLoad/entity/User.java
@@ -1,0 +1,49 @@
+package SilkLoad.entity;
+
+import SilkLoad.entity.UserRoleEnum.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column
+    private String picture;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    public User(String name, String email, String picture, Role role){
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+        this.role = role;
+    }
+
+    public User update(String name, String picture){
+        this.name = name;
+        this.picture = picture;
+        return this;
+    }
+    public String getRoleKey(){
+        return this.role.getKey();
+    }
+
+}

--- a/src/main/java/SilkLoad/entity/UserRoleEnum/Role.java
+++ b/src/main/java/SilkLoad/entity/UserRoleEnum/Role.java
@@ -1,0 +1,15 @@
+package SilkLoad.entity.UserRoleEnum;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+//OAuth2 사용할 때 사용자 권한을 관리하는 Role을 생성
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST", "손님"),
+    USER("ROLE_USER","일반 사용자");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/SilkLoad/repository/MemberRepository.java
+++ b/src/main/java/SilkLoad/repository/MemberRepository.java
@@ -1,14 +1,8 @@
 package SilkLoad.repository;
 
 import SilkLoad.entity.Members;
-import SilkLoad.entity.Product;
-import lombok.Data;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,8 +13,7 @@ public interface MemberRepository extends JpaRepository<Members, Long>{
 
     Optional<Members> findByLoginId(String LoginId);
 
-    Optional<Members> findByName(String name);
-
+    Optional<Members> findByEmail(String email); // 이미 email을 통해 생성된 사용자인지 채크
     @Query("select distinct m from Members m left join fetch m.productList")
     List<Members> findAllJPQLFetch();
 

--- a/src/main/java/SilkLoad/repository/UserRepository.java
+++ b/src/main/java/SilkLoad/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package SilkLoad.repository;
+
+import SilkLoad.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email); // 이미 email을 통해 생성된 사용자인지 채크
+}

--- a/src/main/java/SilkLoad/service/LoginService.java
+++ b/src/main/java/SilkLoad/service/LoginService.java
@@ -2,6 +2,7 @@ package SilkLoad.service;
 
 import SilkLoad.dto.LoginFormDto;
 import SilkLoad.entity.Members;
+import SilkLoad.entity.User;
 import SilkLoad.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,4 +31,15 @@ public class LoginService  {
         return null;
     }
 
+    @Transactional(readOnly = true)
+    public Members loginWithOauth2(String email) {
+
+        Optional<Members> optionalMember = memberRepository.findByEmail(email);
+
+        if (optionalMember.isPresent()) {
+            Members member = optionalMember.get();
+            return member;
+        }
+        return null;
+    }
 }

--- a/src/main/java/SilkLoad/service/MemberService.java
+++ b/src/main/java/SilkLoad/service/MemberService.java
@@ -33,27 +33,19 @@ public class MemberService  {
 
     @Transactional
     public void save(MemberFormDto memberFormDto) {
-
-        Members member = Members.builder()
-                .loginId(memberFormDto.getLoginId())
-                .name(memberFormDto.getName())
-                .password((memberFormDto.getPassword()))
-                .build();
-
-        memberRepository.save(member);
+//        Members member = Members.builder()
+//                .loginId(memberFormDto.getLoginId())
+//                .name(memberFormDto.getName())
+//                .password((memberFormDto.getPassword()))
+//                .build();
+//
+//        memberRepository.save(member);
 
     }
 
     @Transactional
     public Members findByLoginId(String id){
         return memberRepository.findByLoginId(id).get();
-    }
-    @Transactional
-    public Members findById(Long id){
-        if( memberRepository.findById(id).isPresent()) {
-            return memberRepository.findById(id).get();
-        }
-        return null;
     }
 
     @Transactional
@@ -90,14 +82,4 @@ public class MemberService  {
         }
         return null;
     }
-
-
-/*    @Transactional
-    public Page<ProductRecordDto> paged_product(Pageable pageable){
-        Page<ProductRecordDto> sale = productRepository.findByProductTypeOrderByIdDesc(ProductType.sale, pageable).map(this::getProductRecordDto);
-        return sale;
-    }*/
-
-
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,14 +11,14 @@ spring.datasource.hikari.password=alsgh0217
 
 # Resource and Thymeleaf Refresh
 spring.devtools.livereload.enabled=true
-spring.thymeleaf.cache=false
+spring.thymeleaf.cache=true
 spring.servlet.session.tracking-modes=cookie
 
 # JPA Properties
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=update
 
 # sql setting
 spring.jpa.open-in-view=false
@@ -31,8 +31,8 @@ spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 
 #imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
-#imgFile.dir=E:/SilkLoad/file/
-imgFile.dir=/home/ubuntu/img/
+imgFile.dir=E:/SilkLoad/file/
+#imgFile.dir=/home/ubuntu/img/
 
 #spring thymleaf path check
 spring.thymeleaf.prefix=classpath:/templates/
@@ -45,3 +45,8 @@ spring.thymeleaf.prefix=classpath:/templates/
 server.servlet.session.tracking-modes=cookie
 
 spring.messages.basename=errors
+
+#auth2
+spring.profiles.include=oauth
+#when login succese to redirect uri
+#spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080

--- a/src/main/resources/templates/addMemberForm.html
+++ b/src/main/resources/templates/addMemberForm.html
@@ -14,7 +14,6 @@
                     <div class="card-body">
                         <h2 class="h4 mb-1">처음이신가요?</h2>
 
-                        <hr>
                         <h3 class="fs-base pt-4 pb-2">회원가입</h3>
 
                         <form class="needs-validation" action="" th:action="@{/members/add}" th:object="${memberFormDto}"

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -67,27 +67,20 @@
                         </button>
                     </form>
 
-
-
-<!--                    <a class="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2"-->
-<!--                       th:if="${session.loginMember == null }" th:onclick="|location.href='@{/login}'|"-->
-<!--                       data-bs-toggle="modal">-->
-<!--                        <div class="navbar-tool-icon-box"><i class="navbar-tool-icon ci-user"></i></div>-->
-<!--                        <div class="navbar-tool-text ms-n3" th:text="로그인"></div>-->
-<!--                    </a>-->
-<!--                    <div class="row">-->
-<!--                        <a href="/logout" class="btn btn-info active" role="button">Logout</a>-->
-<!--                        <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">로그인</a>-->
-<!--                    </div>-->
+                    <a class="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2"
+                       th:if="${session.loginMember == null }" th:onclick="|location.href='@{/oauth2/authorization/google}'|"
+                       data-bs-toggle="modal">
+                        <div class="navbar-tool-icon-box"><i class="navbar-tool-icon ci-user"></i></div>
+                        <div class="navbar-tool-text ms-n3" th:text="로그인"></div>
+                    </a>
 
                     <!--테스트 하는 곳 -->
-                    <div class="row">
-                        <div class="col-md-6">
-                            Logged in as: <span id = "user"></span>
-                            <a href="/logout" class="btn btn-info active" role="button">Logout</a>
-                            <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
-                        </div>
-                    </div>
+<!--                    <div class="row">-->
+<!--                        <div class="col-md-6">Logged in as: <span id = "user" th:text="${userName}"></span>-->
+<!--                            <a href="/logout" class="btn btn-info active" role="button">Logout</a>-->
+<!--                            <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>-->
+<!--                        </div>-->
+<!--                    </div>-->
 
                     <div class="navbar-tool ms-3">
                         <a class="navbar-tool-icon-box bg-secondary dropdown-toggle"

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -69,14 +69,25 @@
 
 
 
-                    <a class="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2"
-                       th:if="${session.loginMember == null }" th:onclick="|location.href='@{/login}'|"
-                       data-bs-toggle="modal">
-                        <div class="navbar-tool-icon-box"><i class="navbar-tool-icon ci-user"></i></div>
+<!--                    <a class="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2"-->
+<!--                       th:if="${session.loginMember == null }" th:onclick="|location.href='@{/login}'|"-->
+<!--                       data-bs-toggle="modal">-->
+<!--                        <div class="navbar-tool-icon-box"><i class="navbar-tool-icon ci-user"></i></div>-->
+<!--                        <div class="navbar-tool-text ms-n3" th:text="로그인"></div>-->
+<!--                    </a>-->
+<!--                    <div class="row">-->
+<!--                        <a href="/logout" class="btn btn-info active" role="button">Logout</a>-->
+<!--                        <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">로그인</a>-->
+<!--                    </div>-->
 
-                        <div class="navbar-tool-text ms-n3" th:text="로그인"></div>
-                    </a>
-
+                    <!--테스트 하는 곳 -->
+                    <div class="row">
+                        <div class="col-md-6">
+                            Logged in as: <span id = "user"></span>
+                            <a href="/logout" class="btn btn-info active" role="button">Logout</a>
+                            <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+                        </div>
+                    </div>
 
                     <div class="navbar-tool ms-3">
                         <a class="navbar-tool-icon-box bg-secondary dropdown-toggle"

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -3,58 +3,70 @@
       xmlns:th="http://www.thymeleaf.org"
       th:replace="~{layoutFile :: layout(~{::body}, 'login')}">
 
-  <!-- Body-->
-  <body class="handheld-toolbar-enabled">
+<!-- Body-->
+<body class="handheld-toolbar-enabled">
 
-    <main class="page-wrapper">
+<main class="page-wrapper">
 
 
-      <div class="container py-4 py-lg-5 my-4">
+    <div class="container py-4 py-lg-5 my-4">
         <div class="row justify-content-center">
-          <div class="col-md-6">
-            <div class="card border-0 shadow">
-              <div class="card-body">
-                <h2 class="h4 mb-1">로그인</h2>
+            <div class="col-md-6">
+                <div class="card border-0 shadow">
+                    <div class="card-body">
+                        <h2 class="h4 mb-1">로그인</h2>
 
-                <hr>
-                <h3 class="fs-base pt-4 pb-2">안녕하세요</h3>
+                        <hr>
+                        <h3 class="fs-base pt-4 pb-2">안녕하세요</h3>
 
-                <form class="needs-validation" action="" th:action="@{/login}" th:object="${loginFormDto}" method="post"  autocomplete="off" novalidate>
+                        <form class="needs-validation" action="" th:action="@{/login}" th:object="${loginFormDto}"
+                              method="post" autocomplete="off" novalidate>
 
-                  <div th:if="${#fields.hasGlobalErrors()}">
-                    <p class="text-danger" th:each="err : ${#fields.globalErrors()}" th:text="${err}">전체 오류 메시지</p>
-                  </div>
+                            <div th:if="${#fields.hasGlobalErrors()}">
+                                <p class="text-danger" th:each="err : ${#fields.globalErrors()}" th:text="${err}">전체 오류
+                                    메시지</p>
+                            </div>
 
-                  <div class="input-group mb-3"><i class="ci-mail position-absolute top-50 translate-middle-y text-muted fs-base ms-3"></i>
-                    <input class="form-control rounded-start" id="memberLoginid" th:errorclass="field-error" th:field="*{loginId}" type="text" placeholder="Id을 입력하세요" autofocus required>
-                  </div>
+                            <div class="input-group mb-3"><i
+                                    class="ci-mail position-absolute top-50 translate-middle-y text-muted fs-base ms-3"></i>
+                                <input class="form-control rounded-start" id="memberLoginid" th:errorclass="field-error"
+                                       th:field="*{loginId}" type="text" placeholder="Id을 입력하세요" autofocus required>
+                            </div>
 
-                  <div class="input-group mb-3"><i class="ci-locked position-absolute top-50 translate-middle-y text-muted fs-base ms-3"></i>
-                    <div class="password-toggle w-100">
-                      <input class="form-control" type="password" id="spassword" th:field="*{password}" placeholder="비밀번호" required>
-                      <label class="password-toggle-btn" aria-label="Show/hide password">
-                        <input class="password-toggle-check" type="checkbox"><span class="password-toggle-indicator"></span>
-                      </label>
+                            <div class="input-group mb-3"><i
+                                    class="ci-locked position-absolute top-50 translate-middle-y text-muted fs-base ms-3"></i>
+                                <div class="password-toggle w-100">
+                                    <input class="form-control" type="password" id="spassword" th:field="*{password}"
+                                           placeholder="비밀번호" required>
+                                    <label class="password-toggle-btn" aria-label="Show/hide password">
+                                        <input class="password-toggle-check" type="checkbox"><span
+                                            class="password-toggle-indicator"></span>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <hr class="mt-4">
+                            <h3 class="fs-base pt-4 pb-2"><a th:href="@{/members/add}">회원가입</a></h3>
+
+                            <div class="text-end pt-4">
+                                <button class="btn btn-primary" type="submit"><i class="ci-sign-in me-2 ms-n21"></i>Login
+                                    In
+                                </button>
+                            </div>
+                        </form>
+
+                        <!-- form으로 하지 않고 oath로만 가능하게 하기 -->
+                        <div class="row">
+                            <a href="/logout" class="btn btn-info active" role="button">Logout</a>
+                            <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+                        </div>
                     </div>
-                  </div>
-
-                  <hr class="mt-4">
-                  <h3 class="fs-base pt-4 pb-2"><a th:href="@{/members/add}">회원가입</a></h3>
-
-                  <div class="text-end pt-4">
-                    <button class="btn btn-primary" type="submit"><i class="ci-sign-in me-2 ms-n21"></i>Login In</button>
-                  </div>
-
-
-                </form>
-
-              </div>
+                </div>
             </div>
-          </div>
 
         </div>
-      </div>
-    </main>
+    </div>
+</main>
 
-  </body>
+</body>
 </html>


### PR DESCRIPTION
## 📌Linked Issues

- 

## ✏Change Details

- 구글의 OAuth2를 사용해서 User 테이블에 데이터를 넣어봄
- 기존에 있던 Member 테이블에 넣으려면 좀더 시간이 필요할 듯
(9/11)
- 기존에 있는 Member 테이블을 수정
- session에 login 데이터를 넣어서 확인하는 방식은 그대로 동작가능


## 💬Comment

- 기본적으로 spring security를 기반으로 로그인이 진행된다.
- config 파일에 auth라는 폴더로 OAuth시 차단되는 사이트, 리다이렉트 페이지 등 쓸 수 있다.
- application-oauth.yml 파일이 안보일탠데 보안상 gitignore 걸어놔서 커밋이 안되는 것이다. (application-oauth.yml파일 없이 실행하면 오류남)


(9/11)
- Members테이블에 name, email, piceture, role 컬럼 추가
- Members테이블의 loginId의 의도 => OAuth2로 들어온 email로 변경
- Members테이블의 password의 의도 => 삭제(OAuth2에서 관리해줌)
- role의 의미는 스프링 시큐리티에서 권한 접속을 수월하게 하기 위해서 역할을 부여

spring security에서 /login 컨트롤러에 가는 것이 막혀있는듯(지들이 만들어놓은 홈페이지로 들어가짐)

- 시큐리티에서 구글 로그인 성공 하면 customOAuth2UserService라는 것이 제일 먼저 동작하게 됨
- saveOrUpdate()메서드에서 User 테이블과 Memebers 테이블에 로그인 정보를 저장하게됨
- 시큐리티에서 구글 로그인하면 저장된 데이터를 session에 "user"라는 객체이름으로 올려줌
- HomeController에서 session을 받아서 우리꺼에 맞는 "loginmember" 이름의 세션을 올리면 됨


## 📑References

- https://lotuus.tistory.com/79(OAuth의 로그인 흐름 설명해놓은곳)
- https://loosie.tistory.com/300(실제로 코드를 가져다가 쓴 참고사이트)

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?