### PR TITLE
AWS 배포시 img 경로 변경 주의

### DIFF
--- a/src/main/java/SilkLoad/config/auth/SecurityConfig.java
+++ b/src/main/java/SilkLoad/config/auth/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .csrf()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/", "/css/**","/fonts/**","/img/**","/vendor/**", "/js/**").permitAll() // 허용 파일 범위
+                .antMatchers("/", "/css/**","/fonts/**","/img/**","/vendor/**", "/js/**","/product/images/**").permitAll() // 허용 파일 범위
                 .antMatchers("/shop/**").permitAll()
                 .antMatchers("/members/add").permitAll()
                 .antMatchers("/loginMember").permitAll()

--- a/src/main/java/SilkLoad/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/SilkLoad/config/auth/dto/OAuthAttributes.java
@@ -28,10 +28,44 @@ public class OAuthAttributes {
 
     public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
         // 여기서 네이버와 카카오 등 구분 (ofNaver, ofKakao)
-
+        //(new!) kakao
+        if("kakao".equals(registrationId)){
+            return ofKakao("id", attributes);
+        }
+        //(new!) naver
+        if("naver".equals(registrationId)){
+            return ofNaver("id", attributes);
+        }
         return ofGoogle(userNameAttributeName, attributes);
     }
+    // (new!)
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        // kakao는 kakao_account에 유저정보가 있다. (email)
+        Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+        // kakao_account안에 또 profile이라는 JSON객체가 있다. (nickname, profile_image)
+        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
 
+        return OAuthAttributes.builder()
+                .name((String) kakaoProfile.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
+                .picture((String) kakaoProfile.get("profile_image_url"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+    // (new!)
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        // JSON형태이기 떄문에 Map을 통해서 데이터를 가져온다.
+        Map<String, Object> response = (Map<String, Object>)attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .picture((String) response.get("profile_image"))
+                .attributes(response)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
     private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 # mysql ?? (Data Source)
 spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.hikari.jdbc-url=jdbc:mysql://my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com:3306/silkload?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
-#spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+#spring.datasource.hikari.jdbc-url=jdbc:mysql://my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com:3306/silkload?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
 
 
-spring.datasource.hikari.username=admin
+spring.datasource.hikari.username=root
 #admin
-spring.datasource.hikari.password=alsgh0217
+spring.datasource.hikari.password=1234
 #alsgh0217
 
 # Resource and Thymeleaf Refresh
@@ -31,8 +31,8 @@ spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 
 #imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
-#imgFile.dir=E:/SilkLoad/file/
-imgFile.dir=/home/ubuntu/img/
+imgFile.dir=E:/SilkLoad/file/
+#imgFile.dir=/home/ubuntu/img/
 
 #spring thymleaf path check
 spring.thymeleaf.prefix=classpath:/templates/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 # mysql ?? (Data Source)
 spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
-#spring.datasource.hikari.jdbc-url=jdbc:mysql://my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com:3306/silkload?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
-spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.hikari.jdbc-url=jdbc:mysql://my-rds-indstance.cs4f6papfyio.ap-northeast-2.rds.amazonaws.com:3306/silkload?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+#spring.datasource.hikari.jdbc-url=jdbc:mysql://localhost:3306/silkLoad?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
 
 
-spring.datasource.hikari.username=root
+spring.datasource.hikari.username=admin
 #admin
-spring.datasource.hikari.password=1234
+spring.datasource.hikari.password=alsgh0217
 #alsgh0217
 
 # Resource and Thymeleaf Refresh
@@ -30,9 +30,9 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 
-imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
+#imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
 #imgFile.dir=E:/SilkLoad/file/
-#imgFile.dir=/home/ubuntu/img/
+imgFile.dir=/home/ubuntu/img/
 
 #spring thymleaf path check
 spring.thymeleaf.prefix=classpath:/templates/

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -58,7 +58,12 @@
                         <!-- form으로 하지 않고 oath로만 가능하게 하기 -->
                         <div class="row">
                             <a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+                            <!--네이버 로그인 추가-->
+                            <a href="/oauth2/authorization/naver" class="btn btn-secondary active" role="button">Naver Login</a>
+                            <!--카카오 로그인 추가-->
+                            <a href="/oauth2/authorization/kakao" class="btn btn-third active" role="button">Kakao Login</a>
                         </div>
+
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 📌Linked Issues

- 

## ✏Change Details
(9/17)
- Oauth2 네이버, 카카오 구현
- /product/image 경로 security에서 예외처리

## 💬Comment

- 본인 로컬에서 개발시 반드시 로컬 DB에 연결하고 사용할것!!!!!!!!
- why? -> aws db에 넣으면 img 경로가 linux에 없다고 판단되서 rds에 있는 db에 경로를 못찾아서 오류가 뜨는 문제가 있음
- 반드시 로컬 db로 연결하고 개발(로그인, 물품등록, 등등)
(9/17)
- 네이버, 카카오의 사전 승인이 필요하다고 해서 배포에는 적용 못함
## 📑References

- 

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?