### PR TITLE
주문 상태 문제 해결

### DIFF
--- a/src/main/java/SilkLoad/controller/Home/HomeController.java
+++ b/src/main/java/SilkLoad/controller/Home/HomeController.java
@@ -50,7 +50,6 @@ public class HomeController {
                        @PageableDefault(size=8) Pageable pageable) {//@PageableDefault로 기본 8개를 가지고 오게했다crawling.
         List<ProductRecordDto> content = pagedProductService.paged_product(pageable).getContent();
 
-
         model.addAttribute("Products", content);
         model.addAttribute("sale", ProductType.sale);
 //------------------------번개 장터-------------------------

--- a/src/main/java/SilkLoad/controller/Member/MyPageController.java
+++ b/src/main/java/SilkLoad/controller/Member/MyPageController.java
@@ -113,6 +113,7 @@ public class MyPageController {
 
         model.addAttribute("saleOrders", saleOrders);
         model.addAttribute("orderType", OrderType.values() );
+        model.addAttribute("noneTime", ProductTime.NONE );
 
         return "myPage/memberSaleOrders";
     }
@@ -132,6 +133,7 @@ public class MyPageController {
 
         model.addAttribute("purchaseOrders", purchaseOrders);
         model.addAttribute("orderType", OrderType.values());
+        model.addAttribute("noneTime", ProductTime.NONE );
 
         return "myPage/memberPurchaseOrders";
 

--- a/src/main/java/SilkLoad/entity/OrderEnum/OrderType.java
+++ b/src/main/java/SilkLoad/entity/OrderEnum/OrderType.java
@@ -3,9 +3,12 @@ package SilkLoad.entity.OrderEnum;
 public enum OrderType {
 
 
-    unRegistered("미신청"),waiting("경매대기"), cancel("취소"),
-    auction("경매중"),
-    trading("거래중"), bidding("낙찰"), complete("거래완료");
+    unRegistered("미신청"),
+    bid("입찰"),
+    successfulBid("낙찰"),
+    buyNow("바로 구매"),
+    cancel("취소"),
+    complete("거래완료");
     private final String description;
 
     OrderType(String description) {

--- a/src/main/java/SilkLoad/entity/ProductEnum/ProductType.java
+++ b/src/main/java/SilkLoad/entity/ProductEnum/ProductType.java
@@ -2,13 +2,10 @@ package SilkLoad.entity.ProductEnum;
 
 public enum ProductType {
 
-    sale("판매 중"), 
-    soldOut("판매 완료"), 
-    trading("거래 중"), 
-    bidding("낙찰"),
-    auction("경매중"),
+    sale("판매"),
+    soldOut("판매 완료"),
+    trading("거래"),
     cancel("거래 취소");
-
     private final String description;
 
     ProductType(String description) {

--- a/src/main/java/SilkLoad/service/MemberService.java
+++ b/src/main/java/SilkLoad/service/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService  {
     @Transactional
     public void save(MemberFormDto memberFormDto) {
         Members member = Members.builder()
-                .name(memberFormDto.getLoginId())
+                .name(memberFormDto.getName())
                 .password(memberFormDto.getPassword())
                 .email(memberFormDto.getLoginId())
                 .picture(null)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,8 +33,8 @@ spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 
 #imgFile.dir=C:/Users/khyb1.DESKTOP-0O3J1H8/CD_Back/file/
-#imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
-imgFile.dir=E:/SilkLoad/file/
+imgFile.dir=C:/Users/82103/IdeaProjects/Spring/schoolProject/CD_Back/file/
+#imgFile.dir=E:/SilkLoad/file/
 #imgFile.dir=/home/ubuntu/img/
 
 #spring thymleaf path check

--- a/src/main/resources/templates/detailProduct.html
+++ b/src/main/resources/templates/detailProduct.html
@@ -140,15 +140,15 @@
                                             <ul class="fs-sm ps-4">
                                                 <li class="" th:text="${product.productTime.getDescription()}"></li>
                                             </ul>
-
-                                            <h6 class="fs-sm mb-2"
-                                                th:classappend="${product.productTime.equals( productTime[2])} ?  'd-none' : ''">
+                                            <span th:classappend="${product.productTime.equals( productTime[2])} ?  'd-none' : ''">
+                                            <h6 class="fs-sm mb-2">
                                                 경매 가격 </h6>
                                             <ul class="fs-sm ps-4">
                                                 <li class=""
-                                                th:text="|${#numbers.formatInteger((maxAuctionPrice == -1 ? product.instantPrice : maxAuctionPrice), 0, 'COMMA')} 원|"></li></span>
+                                                th:text="|${#numbers.formatInteger((maxAuctionPrice == -1 ? product.auctionPrice : maxAuctionPrice ), 0, 'COMMA')} 원|"></li></span>
                                                 <!--                                                    th:text="${maxAuctionPrice} == -1 ? ${product.auctionPrice} : ${ maxAuctionPrice }"></li></span>-->
                                             </ul>
+                                            </span>
 
                                             <h6 class="fs-sm mb-2">상세 설명</h6>
                                             <ul class="fs-sm ps-4">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -44,7 +44,7 @@
                         </h3>
                         <div>
                             <div class="product-price col"><span class="text-accent"
-                                                                 th:text="|즉시구매가: ${#numbers.formatInteger(product.instantPrice, 0, 'COMMA')} 원|"></span>
+                                                                 th:text="|바로 구매가: ${#numbers.formatInteger(product.instantPrice, 0, 'COMMA')} 원|"></span>
                             </div>
                             <!--                                                                 th:text="|즉시 구매가: ${product.instantPrice} 원 |"></span></div>-->
                             <div class="product-price col"><span class="text-accent"

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -57,28 +57,26 @@
                         <span class="navbar-tool-tooltip">Wishlist</span>
                         <div class="navbar-tool-icon-box"><i class="navbar-tool-icon ci-heart"></i></div>
                     </a>
-
                     <div
                             class="navbar-tool dropdown"
-                            href="javascript:void(0)"
                             data-bs-toggle="collapse"
                             data-bs-target="#alarmList"
                             onclick="window.scrollTo(0, 0)"
                     >
-                        <a class="navbar-tool-icon-box bg-s econdary dropdown-toggle">
-                            <span class="navbar-tool-label">3</span>
-                            <i class="navbar-tool-icon ci-bell"></i>
-                        </a>
+                        <a class="navbar-tool-icon-box bg-s econdary dropdown-toggle"
+                        ><span class="navbar-tool-label">3</span
+                        ><i class="navbar-tool-icon ci-bell"></i
+                        ></a>
 
                         <!-- Cart dropdown-->
                         <div class="dropdown-menu dropdown-menu-end" id="alarmList">
                             <div
                                     class="widget widget-cart px-3 pt-2 pb-3"
                                     style="width: 23rem"
-                                    data-bs-toggle="dropdown"
+                                    data-bs-toggle="dropdown
+                    "
                             >
                                 <div
-                                        id="message-box"
                                         style="height: 15rem"
                                         data-simplebar
                                         data-simplebar-auto-hide="false"
@@ -86,18 +84,20 @@
                                     <div class="pb-2">
                                         <div class="ps-2">
                                             <h4 class="widget-product-title">
-                                                <a href="/"><h5>알림</h5></a>
+                                                <a href="shop-single-v1.html"><h5>알림</h5></a>
                                             </h4>
                                         </div>
-                                        <hr class="border border-2 rounded border-primary bg-primary mb-1"/>
+                                        <hr
+                                                class="border border-2 rounded border-primary bg-primary mb-1"
+                                        />
                                     </div>
+
 
                                 </div>
 
                             </div>
                         </div>
                     </div>
-
                     <!-- 로그인 버튼 #signin-modal-->
                     <form class="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2"
                           th:if="${session.loginMember != null }" th:action="@{/logout}" method="post"
@@ -262,7 +262,7 @@
                 const notificationResponseDto = JSON.parse(e.data);
 
                 $(".simplebar-content").append(
-                    '<div class="pb-2">' +
+                    '<div class="widget-cart-item pb-2">' +
                     '<div class="ps-2">' +
                     '<h6 class="widget-product-title">' +
                     '<a href="' +
@@ -281,7 +281,6 @@
                     '<hr class="border border-1 mt-1"/>' +
                     '</div>' +
                     '</div>'
-
                 )
 
 

--- a/src/main/resources/templates/myPage/memberPurchaseOrders.html
+++ b/src/main/resources/templates/myPage/memberPurchaseOrders.html
@@ -69,9 +69,9 @@
 
                                     <div class="py-2"> 물품 번호:&nbsp&nbsp<span th:text="${purchaseOrder.productId}"></span></div>
                                     <div class="py-2"> 물품 이름:&nbsp&nbsp<span th:text="${purchaseOrder.productName}"></span></div>
-                                    <div class="py-2"> 경매 가격:&nbsp&nbsp<span th:text=" ( ${purchaseOrder.auctionPrice} == null ) ? '-': ${purchaseOrder.auctionPrice} "></span>
+                                    <div class="py-2"> 경매 시작가:&nbsp&nbsp<span th:text=" ( ${purchaseOrder.auctionPrice} == null ) ? '-': ${purchaseOrder.auctionPrice} "></span>
                                     </div>
-                                    <div class="py-2"> 즉시 구매가:&nbsp&nbsp<span th:text="${purchaseOrder.instantPrice}"></span>
+                                    <div class="py-2"> 바로 구매가:&nbsp&nbsp<span th:text="${purchaseOrder.instantPrice}"></span>
 
                                     </div>
 
@@ -95,8 +95,14 @@
                                     <div class="py-2"> 주문 상태:&nbsp&nbsp<span th:text="${purchaseOrder.orderType.description}"></span>
 
                                     </div>
-                                    <div class="py-2"> 주문 제시 가격:&nbsp&nbsp<span th:text=" ( ${purchaseOrder.offerPrice} == -1 ) ? '-' : ${purchaseOrder.offerPrice}"></span>
-
+                                    <div class="py-2" th:if="${purchaseOrder.orderType} == ${orderType[1]}" > 입찰가:&nbsp&nbsp<span
+                                            th:text=" ( ${purchaseOrder.offerPrice} == -1 ) ? '-' : ${purchaseOrder.offerPrice}"></span>
+                                    </div>
+                                    <div class="py-2" th:if="${purchaseOrder.orderType} == ${orderType[2]}" > 낙찰가:&nbsp&nbsp<span
+                                            th:text=" ( ${purchaseOrder.offerPrice} == -1 ) ? '-' : ${purchaseOrder.offerPrice}"></span>
+                                    </div>
+                                    <div class="py-2" th:if="${purchaseOrder.orderType} == ${orderType[3]}" > 바로 구매:&nbsp&nbsp<span
+                                            th:text=" ( ${purchaseOrder.offerPrice} == -1 ) ? '-' : ${purchaseOrder.offerPrice}"></span>
                                     </div>
                                     <div class="py-2"> 구매자 이름:&nbsp&nbsp<span th:text=" ( ${purchaseOrder.orderType } == ${orderType[0] } ) ? '-' : ${purchaseOrder.buyerName}"></span>
 
@@ -127,9 +133,10 @@
                         <thead>
                         <tr class="text-center">
                             <th>물품 이름</th>
+                            <th>판매 형식</th>
                             <th>물품 상태</th>
-                            <th>경매 가</th>
-                            <th>즉시 구매가</th>
+                            <th>현재 입찰가</th>
+                            <th>바로 구매가</th>
                             <th>등록 날짜</th>
                         </tr>
                         </thead>
@@ -138,12 +145,16 @@
                         <tr class="text-center" th:each="purchaseOrder, purchaseStat : ${purchaseOrders}">
 
                             <td class="py-3">
-                                <button type="button" class="btn btn-primary btn-sm d-none d-lg-inline-block"
+                                <button type="button" class="btn btn-primary btn-sm d-lg-inline-block"
                                         th:text="${ purchaseOrder.productName }" data-bs-toggle="modal"
                                         th:data-bs-target="|#myModal${purchaseStat.index}|"></button>
                             </td>
-                            <td class="py-3 align-middle" th:text="${ purchaseOrder.productType.description }"></td>
-                            <td class="py-3 align-middle" th:text=" (${purchaseOrder.auctionPrice} == null) ? '-' : ${ purchaseOrder.auctionPrice }"></td>
+                            <td class="py-3 align-middle" th:text="${purchaseOrder.productTime == noneTime  ?
+                             '비경매 ' : '경매 ' }"></td>
+                            <td class="py-3 align-middle" th:text="${purchaseOrder.productType.description }"></td>
+
+                            <td class="py-3 align-middle"
+                                th:text=" (${purchaseOrder.offerPrice} == -1 ) ? '-' : ${ purchaseOrder.offerPrice }"></td>
                             <td class="py-3 align-middle" th:text="${ purchaseOrder.instantPrice}"></td>
                             <td class="py-3 align-middle"
                                 th:text="${#temporals.format( purchaseOrder.productDateTime , 'yy-MM-dd HH:mm')}"></td>

--- a/src/main/resources/templates/myPage/memberSaleOrders.html
+++ b/src/main/resources/templates/myPage/memberSaleOrders.html
@@ -69,16 +69,17 @@
 
                                 <div class="py-2"> 물품 번호:&nbsp&nbsp<span th:text="${saleOrder.productId}"></span></div>
                                 <div class="py-2"> 물품 이름:&nbsp&nbsp<span th:text="${saleOrder.productName}"></span>
+
                                 </div>
-                                <div class="py-2"> 경매 가격:&nbsp&nbsp<span
+                                <div class="py-2"> 경매 시작가:&nbsp&nbsp<span
                                         th:text=" ( ${saleOrder.auctionPrice} == null ) ? '-': ${saleOrder.auctionPrice} "></span>
                                 </div>
-                                <div class="py-2"> 즉시 구매가:&nbsp&nbsp<span th:text="${saleOrder.instantPrice}"></span>
+                                <div class="py-2"> 바로 구매가:&nbsp&nbsp<span th:text="${saleOrder.instantPrice}"></span>
 
                                 </div>
 
                                 <div class="py-2"> 물품 상태:&nbsp&nbsp<span
-                                        th:text="${saleOrder.orderType.description}"></span>
+                                        th:text="${saleOrder.productType.description}"></span>
 
                                 </div>
                                 <div class="py-2"> 등록 상태:&nbsp&nbsp<span
@@ -101,8 +102,14 @@
                                 <div class="py-2"> 주문 상태:&nbsp&nbsp<span
                                         th:text="${saleOrder.orderType.description}"></span>
                                 </div>
-                                <div class="py-2"> 주문 제시 가격:&nbsp&nbsp
-                                    <span th:text=" ( ${saleOrder.offerPrice} == -1 ) ? '-' : ${saleOrder.offerPrice}"></span>
+                                <div class="py-2" th:if="${saleOrder.orderType} == ${orderType[1]}" > 입찰가:&nbsp&nbsp<span
+                                        th:text=" ( ${saleOrder.offerPrice} == -1 ) ? '-' : ${saleOrder.offerPrice}"></span>
+                                </div>
+                                <div class="py-2" th:if="${saleOrder.orderType} == ${orderType[2]}" > 낙찰가:&nbsp&nbsp<span
+                                        th:text=" ( ${saleOrder.offerPrice} == -1 ) ? '-' : ${saleOrder.offerPrice}"></span>
+                                </div>
+                                <div class="py-2" th:if="${saleOrder.orderType} == ${orderType[3]}" > 바로 구매:&nbsp&nbsp<span
+                                        th:text=" ( ${saleOrder.offerPrice} == -1 ) ? '-' : ${saleOrder.offerPrice}"></span>
                                 </div>
                                 <div class="py-2"> 구매자 이름:&nbsp&nbsp<span
                                         th:text=" ( ${saleOrder.orderType } == ${orderType[0] } ) ? '-' : ${saleOrder.buyerName}"></span>
@@ -122,7 +129,7 @@
                                       th:action="@{/product/order/transaction/complete/{param1}(param1=${saleOrder.orderId})}"
                                       method="post">
                                     <button type="submit" class="btn btn-danger" data-bs-dismiss="modal"
-                                            th:classappend="(${saleOrder.orderType} == ${orderType[3]}) ? '' : 'd-none' ">
+                                            th:if="(${saleOrder.orderType} == ${orderType[3]} or ${saleOrder.orderType} == ${orderType[2]} ) ">
                                         주문 완료
                                     </button>
                                 </form>
@@ -130,7 +137,7 @@
                                       th:action="@{/product/order/transaction/trading/{param1}(param1=${saleOrder.orderId})}"
                                       method="post">
                                     <button type="submit" class="btn btn-danger" data-bs-dismiss="modal"
-                                            th:classappend="(${saleOrder.orderType} == ${orderType[1]}) ? '' : 'd-none' ">
+                                            th:if="(${saleOrder.orderType} == ${orderType[1]})">
                                         주문 수락
                                     </button>
                                 </form>
@@ -139,7 +146,8 @@
                                       th:action="@{/product/order/transaction/cancel/{param1}(param1=${saleOrder.orderId})}"
                                       method="post">
                                     <button type="submit" class="btn btn-danger" data-bs-dismiss="modal"
-                                            th:classappend="(${saleOrder.orderType} != ${orderType[4]} and ${saleOrder.orderType} != ${orderType[2]} ) ? '' : 'd-none' ">
+                                            th:if="(${saleOrder.orderType} != ${orderType[4]} and
+                                             ${saleOrder.orderType} != ${orderType[5]}  )">
                                         주문 취소
                                     </button>
                                 </form>
@@ -161,9 +169,10 @@
                     <thead>
                     <tr class="text-center">
                         <th>물품 이름</th>
+                        <th>판매 형식</th>
                         <th>물품 상태</th>
-                        <th>경매 가</th>
-                        <th>즉시 구매가</th>
+                        <th>현재 입찰가</th>
+                        <th>바로 구매가</th>
                         <th>등록 날짜</th>
                     </tr>
                     </thead>
@@ -176,9 +185,11 @@
                                     th:text="${ saleOrder.productName }" data-bs-toggle="modal"
                                     th:data-bs-target="|#myModal${saleOrderStat.index}|"></button>
                         </td>
+                        <td class="py-3 align-middle" th:text="${saleOrder.productTime == noneTime  ?
+                             '비경매 ' : '경매 ' }"></td>
                         <td class="py-3 align-middle" th:text="${ saleOrder.productType.description }"></td>
                         <td class="py-3 align-middle"
-                            th:text=" (${saleOrder.auctionPrice} == null) ? '-' : ${ saleOrder.auctionPrice }"></td>
+                            th:text=" (${saleOrder.offerPrice} == -1 ) ? '-' : ${ saleOrder.offerPrice }"></td>
                         <td class="py-3 align-middle" th:text="${ saleOrder.instantPrice}"></td>
                         <td class="py-3 align-middle"
                             th:text="${#temporals.format( saleOrder.productDateTime , 'yy-MM-dd HH:mm')}"></td>


### PR DESCRIPTION
# 주문 상태 문제 해결

+ 주문 완료, 주문 취소 버그 발견
  + 주문 상태를 추가하며  thymleaf 코드를 변경하지 않아 발생한 문제

+ 경매, 비경매 문제 해결
  + 구매, 판매 페이지의 물품 테이블에  판매 형식 속성 추가
    + 속성 값은, 경배 or 비경매


+ 주문 타입 변경
  + 기존의 watting("주문 중") 을 2가지로 나눔
    + 입찰과, 바로구매
  + 낙찰 타입 추가
    + 입찰 형식으로 주문을 보내고 판매자가 주문을 받았을 상태
  + 주문 속성 변경
    + 기존에는 ''즉시 구매''로 표현했었는데 ''바로 구매''로 표현
    + 경매 가 => 경매 시작가로 변경



+ 물품 타입 삭제
  + 추가 했었던 "낙찰",  "경매중 " 상태 삭제
    + 낙찰은 주문 entity로 설명가능
    + 경매, 비경매는 productTime으로 설명가능함



+ 개인정보 페이지 문제 해결
  + 기존 형식으로 로그인을 했을 때  ID와 NAME이 똑같이 나오는 현상 수정
    + 회원 가입 할 때 NAME에 ID를 집어 넣게 코드가 변경되어 있었음



+ 알림 메시지 클릭을 통한 페이지 이동

  + 이제 메시지를 클릭하면 메시지와 관련된 페이지로 이동됨

    

+ 기타 버그

  + oauth2.0을 통한 로그인시 error 페이지로 이동하는 버그가 아직도 남아있음

    



