### PR TITLE
알람개수 표시 구현, 홈, 판매주문, 구매주문, 채팅방 로그아웃 버튼 수정

### DIFF
--- a/src/main/java/SilkLoad/config/auth/SecurityConfig.java
+++ b/src/main/java/SilkLoad/config/auth/SecurityConfig.java
@@ -37,9 +37,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/product/**").hasRole(Role.GUEST.name()) // guest 사용자만 들어갈 수 있따. 들어온 String 뒤에 자동으로 _ROLE 붙여준다.
                 .antMatchers("/members/**").hasRole(Role.GUEST.name()) // username이 있는 사용자만 들어갈 수 있따.
                 .antMatchers("/chat/**").hasRole(Role.GUEST.name()) // username이 있는 사용자만 들어갈 수 있따.
-//                .antMatchers("/product/**").permitAll() // guest 사용자만 들어갈 수 있따. 들어온 String 뒤에 자동으로 _ROLE 붙여준다.
-//                .antMatchers("/members/**").permitAll() // username이 있는 사용자만 들어갈 수 있따.
-//                .antMatchers("/chat/**").permitAll() // username이 있는 사용자만 들어갈 수 있따.
                 .anyRequest()
                 .authenticated()
                 .and()

--- a/src/main/java/SilkLoad/controller/Alarm/NotificationController.java
+++ b/src/main/java/SilkLoad/controller/Alarm/NotificationController.java
@@ -33,9 +33,7 @@ public class NotificationController {
                                 ) {
 
         MemberSessionDto sessionMembers = MyPageController.getSessionMembers(request);
-        log.info( "lastEventId ={}" ,lastEventId);
         SseEmitter sseEmitter = notificationService.subscribe(sessionMembers.getId(), lastEventId);
-
         return sseEmitter;
 
     }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -13,7 +13,7 @@
         <div class="d-flex flex-wrap justify-content-between align-items-center pt-1 border-bottom pb-4 mb-4">
             <h2 class="h3 mb-0 pt-3 me-2">Today products</h2>
             <div class="pt-3">
-                <a class="btn btn-outline-accent btn-sm" th:onclick="|location.href='@{/}'|">
+                <a class="btn btn-outline-accent btn-sm" th:onclick="|location.href='@{/shop/(first=여성의류,second=맨투맨)}'|">
                     More products
                     <i class="ci-arrow-right ms-1 me-n1"></i>
                 </a>

--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -63,18 +63,17 @@
                             data-bs-target="#alarmList"
                             onclick="window.scrollTo(0, 0)"
                     >
-                        <a class="navbar-tool-icon-box bg-s econdary dropdown-toggle"
-                        ><span class="navbar-tool-label">3</span
-                        ><i class="navbar-tool-icon ci-bell"></i
-                        ></a>
+                        <a class="navbar-tool-icon-box bg-s econdary dropdown-toggle">
+                            <span class="navbar-tool-label alarm-count">0</span>
+                            <i class="navbar-tool-icon ci-bell"></i>
+                        </a>
 
                         <!-- Cart dropdown-->
                         <div class="dropdown-menu dropdown-menu-end" id="alarmList">
                             <div
                                     class="widget widget-cart px-3 pt-2 pb-3"
                                     style="width: 23rem"
-                                    data-bs-toggle="dropdown
-                    "
+                                    data-bs-toggle="dropdown"
                             >
                                 <div
                                         style="height: 15rem"
@@ -91,13 +90,11 @@
                                                 class="border border-2 rounded border-primary bg-primary mb-1"
                                         />
                                     </div>
-
-
                                 </div>
-
                             </div>
                         </div>
                     </div>
+
                     <!-- 로그인 버튼 #signin-modal-->
                     <form class="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2"
                           th:if="${session.loginMember != null }" th:action="@{/logout}" method="post"
@@ -246,6 +243,8 @@
         if (memberSession != null) {
             const eventSource = new EventSource(`/subscribe`);
 
+            console.log("eventSource")
+            console.log(eventSource)
             eventSource.onopen = (e) => {
                 console.log(e);
             };
@@ -254,13 +253,12 @@
                 console.log(e);
             };
             /**
-             *
              * @param e.data : message, createdDateTime, url
              */
+            let alramCount = 0;
             eventSource.onmessage = (e) => {
-
                 const notificationResponseDto = JSON.parse(e.data);
-
+                alramCount += 1;
                 $(".simplebar-content").append(
                     '<div class="widget-cart-item pb-2">' +
                     '<div class="ps-2">' +
@@ -282,10 +280,10 @@
                     '</div>' +
                     '</div>'
                 )
-
-
+                $(".alarm-count").text(
+                    alramCount
+                )
             };
-
         }
     }))
 

--- a/src/main/resources/templates/myPage/memberChatRoomList.html
+++ b/src/main/resources/templates/myPage/memberChatRoomList.html
@@ -30,9 +30,16 @@
             <!-- Content  -->
             <section class="col-lg-8">
                 <div class="d-flex justify-content-between align-items-center pt-lg-2 pb-4 pb-lg-5 mb-lg-3">
-                    <h6 class="text-white">your ChatRoomList </h6>
-                    <a class="btn btn-primary btn-sm d-none d-lg-inline-block" href="account-signin.html"><i
-                            class="ci-sign-out me-2"></i>Sign out</a>
+                    <h6 class="text-white">채팅방 입니다.</h6>
+                    <!-- 로그아웃 버튼 -->
+                    <form class="btn btn-primary btn-sm d-none d-lg-inline-block" method="post"
+                          th:if="${session.loginMember != null }" th:action="@{/logout}"
+                          data-bs-toggle="modal">
+
+                        <button class="btn btn-primary btn-sm d-none d-lg-inline-block" type="submit">
+                            <i class="ci-sign-out me-2"></i>로그아웃
+                        </button>
+                    </form>
                 </div>
                 <div class="table-responsive fs-md mb-4">
                     <table class="table table-hover mb-0">

--- a/src/main/resources/templates/myPage/memberPurchaseOrders.html
+++ b/src/main/resources/templates/myPage/memberPurchaseOrders.html
@@ -34,19 +34,19 @@
                 <!-- Toolbar-->
                 <div class="d-flex justify-content-between align-items-center pt-lg-2 pb-4 pb-lg-5 mb-lg-3">
                     <div class="d-flex align-items-center">
-                        <label class="d-none d-lg-block fs-sm text-light text-nowrap opacity-75 me-2" for="order-sort">Sort
-                            orders:</label>
-                        <label class="d-lg-none fs-sm text-nowrap opacity-75 me-2" for="order-sort">Sort orders:</label>
-                        <select class="form-select" id="order-sort">
-                            <option>All</option>
-                            <option>Delivered</option>
-                            <option>In Progress</option>
-                            <option>Delayed</option>
-                            <option>Canceled</option>
-                        </select>
+                        <h6 class="fs-base text-light mb-0">구매주문 페이지 입니다.</h6>
                     </div>
-                    <a class="btn btn-primary btn-sm d-none d-lg-inline-block" href="account-signin.html"><i
-                            class="ci-sign-out me-2"></i>Sign out</a>
+<!--                    <a class="btn btn-primary btn-sm d-none d-lg-inline-block" href="account-signin.html"><i-->
+<!--                            class="ci-sign-out me-2"></i>Sign out</a>-->
+                    <!-- 로그아웃 버튼 -->
+                    <form class="btn btn-primary btn-sm d-none d-lg-inline-block" method="post"
+                          th:if="${session.loginMember != null }" th:action="@{/logout}"
+                          data-bs-toggle="modal">
+
+                        <button class="btn btn-primary btn-sm d-none d-lg-inline-block" type="submit">
+                            <i class="ci-sign-out me-2"></i>로그아웃
+                        </button>
+                    </form>
                 </div>
 
                 <th:block th:each="purchaseOrder, purchaseStat : ${purchaseOrders}">

--- a/src/main/resources/templates/myPage/memberSaleOrders.html
+++ b/src/main/resources/templates/myPage/memberSaleOrders.html
@@ -31,22 +31,23 @@
         <div th:replace="~{myPage/myPageSidebar:: sidebar('saleOrders')}"></div>
         <!-- Content  -->
         <section class="col-lg-8">
+
             <!-- Toolbar-->
             <div class="d-flex justify-content-between align-items-center pt-lg-2 pb-4 pb-lg-5 mb-lg-3">
                 <div class="d-flex align-items-center">
-                    <label class="d-none d-lg-block fs-sm text-light text-nowrap opacity-75 me-2" for="order-sort">Sort
-                        orders:</label>
-                    <label class="d-lg-none fs-sm text-nowrap opacity-75 me-2" for="order-sort">Sort orders:</label>
-                    <select class="form-select" id="order-sort">
-                        <option>All</option>
-                        <option>Delivered</option>
-                        <option>In Progress</option>
-                        <option>Delayed</option>
-                        <option>Canceled</option>
-                    </select>
+                    <h6 class="fs-base text-light mb-0">판매주문 페이지 입니다.</h6>
                 </div>
-                <a class="btn btn-primary btn-sm d-none d-lg-inline-block" href="account-signin.html"><i
-                        class="ci-sign-out me-2"></i>Sign out</a>
+<!--                <a class="btn btn-primary btn-sm d-none d-lg-inline-block" href="account-signin.html"><i-->
+<!--                        class="ci-sign-out me-2"></i>Sign out</a>-->
+                <!-- 로그아웃 버튼 -->
+                <form class="btn btn-primary btn-sm d-none d-lg-inline-block" method="post"
+                      th:if="${session.loginMember != null }" th:action="@{/logout}"
+                      data-bs-toggle="modal">
+
+                    <button class="btn btn-primary btn-sm d-none d-lg-inline-block" type="submit">
+                        <i class="ci-sign-out me-2"></i>로그아웃
+                    </button>
+                </form>
             </div>
 
             <th:block th:each="saleOrder, saleOrderStat : ${saleOrders}">


### PR DESCRIPTION
## ✏Change Details

- 알람개수 표시 구현

- 알람의 개수 표시
  - 기본은 0

홈 수정
- 오른쪽에 view More 버튼 shop페이지로 가게끔 수정

마이페이지 - 판매 주문
- sort 버튼 삭제
  - 판매주문 페이지 입니다.로 수정
- 로그아웃 버튼 수정

마이페이지 - 구매 주문
- sort 버튼 삭제
  - 판매주문 페이지 입니다.로 수정
- 로그아웃 버튼 수정

채팅방
- 로그아웃 버튼 수정
- your chatroom 문구 수정
  - 채팅방 입니다로 변경


## 💬Comment

-  로그인 페이지 화면 작아질 때 너무 작아지는거 수정해야할 듯

## 📑References

- 

## ✅Check List

-  추가한 기능에 대한 테스트는 모두 완료하셨나요?
-  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?