### PR TITLE
모바일 handheld-toolbar 카테고리 버튼 추가

### DIFF
--- a/src/main/resources/templates/layoutFile.html
+++ b/src/main/resources/templates/layoutFile.html
@@ -187,6 +187,16 @@
 <div class="handheld-toolbar">
     <div class="d-table table-layout-fixed w-100">
 
+        <a th:if="${paramActive == 'shop'}"
+            class="d-table-cell handheld-toolbar-item"
+                href="#"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#shop-sidebar"
+        ><span class="handheld-toolbar-icon"
+        ><i class="ci-filter-alt"></i></span
+        ><span class="handheld-toolbar-label">카테고리</span></a
+        >
+
         <a class="d-table-cell handheld-toolbar-item" href="javascript:void(0)" data-bs-toggle="collapse"
            data-bs-target="#navbarCollapse" onclick="window.scrollTo(0, 0)">
         <span class="handheld-toolbar-icon">

--- a/src/main/resources/templates/myPage/memberChatRoomList.html
+++ b/src/main/resources/templates/myPage/memberChatRoomList.html
@@ -67,12 +67,12 @@
                     </table>
                 </div>
                 <!-- Pagination-->
-                <nav class="d-flex justify-content-between pt-2" aria-label="Page navigation" th:if="${totalPages != 0}">
+                <nav class="d-flex justify-content-center pt-2" aria-label="Page navigation" th:if="${totalPages != 0}">
 
                     <ul class="pagination">
                         <li class="page-item">
-                            <a class="page-link"  th:href="@{/members/myPage/myChatRoomList(page=${presentPage}-1)}">
-                                <i class="ci-arrow-left me-2"></i>Prev
+                            <a class="page-link"  th:href="@{/members/myPage/myChatRoomList(page=${presentPage})}">
+                                <i class="ci-arrow-left me-2"></i>
                             </a>
                         </li>
                     </ul>
@@ -80,26 +80,26 @@
                     <ul class="pagination">
                         <li class="page-item">
                             <a class="page-link" th:href="@{/members/myPage/myChatRoomList(page = 1)}">
-                                <i class="ci-arrow-left me-2"></i>First
+                                <i class="ci-arrow-left me-2"></i>
                             </a>
                         </li>
                     </ul>
 
-                    <ul class="pagination">
-                        <th:block th:with="start = ${ T(Math).floor(presentPage/10) * 10 +1 },
+                    <ul class="pagination row justify-content-center">
+                        <th:block th:with="start = ${T(Math).floor(presentPage/10) * 10 +1},
                                             end = (${start + 9 < totalPages ? start+9 : totalPages})">
-                            <li class="page-item"
+                            <li class="page-item col-1 d-flex"
                                 th:each="pageButton : ${#numbers.sequence(start, end)}">
                                 <a class="page-link" th:classappend="( ${ pageButton == presentPage + 1 }) ? 'bg-primary text-white'  : '' " th:href="@{/members/myPage/myChatRoomList(page = ${pageButton})}" th:text="${pageButton}"></a>
                             </li>
                         </th:block>
-<!--                        th:text=" ( ${saleOrder.auctionPrice} == null ) ? '-': ${saleOrder.auctionPrice} "></span>-->
-<!--                        th:classappend="(${saleOrder.orderType} == ${orderType[3]}) ? '' : 'd-none' " -->
                     </ul>
 
-                    <ul class="pagination">
+
+
+                    <ul class="pagination ps-4">
                         <li class="page-item">
-                            <a class="page-link"th:href="@{/members/myPage/myChatRoomList(page=${totalPages})}" aria-label="Next">Last
+                            <a class="page-link"th:href="@{/members/myPage/myChatRoomList(page=${totalPages})}" aria-label="Next">
                                 <i class="ci-arrow-right ms-2"></i>
                             </a>
                         </li>
@@ -107,7 +107,7 @@
 
                     <ul class="pagination">
                         <li class="page-item">
-                            <a class="page-link"th:href="@{/members/myPage/myChatRoomList(page=${presentPage}+1)}" aria-label="Next">Next
+                            <a class="page-link"  th:href="@{/members/myPage/myChatRoomList(page=${presentPage + 2 > totalPages ? presentPage + 1: presentPage + 2})}" aria-label="Next">
                                 <i class="ci-arrow-right ms-2"></i>
                             </a>
                         </li>

--- a/src/main/resources/templates/myPage/memberPurchaseOrders.html
+++ b/src/main/resources/templates/myPage/memberPurchaseOrders.html
@@ -192,7 +192,7 @@
 
                     <ul class="pagination">
                         <li class="page-item">
-                            <a class="page-link"  th:href="@{/members/myPage/purchaseOrders(page=${presentPage}-1)}">
+                            <a class="page-link"  th:href="@{/members/myPage/purchaseOrders(page=${presentPage})}">
                                 <i class="ci-arrow-left me-2"></i>
                             </a>
                         </li>
@@ -226,7 +226,7 @@
 
                     <ul class="pagination">
                         <li class="page-item">
-                            <a class="page-link"th:href="@{/members/myPage/purchaseOrders(page=${presentPage}+1)}" aria-label="Next">
+                            <a class="page-link"   th:href="@{/members/myPage/purchaseOrders(page=${presentPage + 2 > totalPages ? presentPage + 1: presentPage + 2})}" aria-label="Next">
                                 <i class="ci-arrow-right ms-2"></i>
                             </a>
                         </li>

--- a/src/main/resources/templates/myPage/memberSaleOrders.html
+++ b/src/main/resources/templates/myPage/memberSaleOrders.html
@@ -215,7 +215,7 @@
 
                 <ul class="pagination">
                     <li class="page-item">
-                        <a class="page-link"  th:href="@{/members/myPage/saleOrders(page=${presentPage}-1)}">
+                        <a class="page-link"  th:href="@{/members/myPage/saleOrders(page=${presentPage})}">
                             <i class="ci-arrow-left me-2"></i>
                         </a>
                     </li>
@@ -249,7 +249,7 @@
 
                 <ul class="pagination">
                     <li class="page-item">
-                        <a class="page-link"th:href="@{/members/myPage/saleOrders(page=${presentPage}+1)}" aria-label="Next">
+                        <a class="page-link"th:href="@{/members/myPage/saleOrders(page=${presentPage + 2 > totalPages ? presentPage + 1: presentPage + 2})}" aria-label="Next">
                             <i class="ci-arrow-right ms-2"></i>
                         </a>
                     </li>

--- a/src/main/resources/templates/myPage/memberWishlist.html
+++ b/src/main/resources/templates/myPage/memberWishlist.html
@@ -98,12 +98,12 @@
                 </div>
 
                 <!-- Pagination-->
-                <nav class="d-flex justify-content-between pt-2" aria-label="Page navigation " th:if="${totalPages != 0}">
+                <nav class="d-flex justify-content-center pt-2" aria-label="Page navigation " th:if="${totalPages != 0}">
 
                     <ul class="pagination">
                         <li class="page-item">
-                            <a class="page-link" th:href="@{/members/myPage/wishlist(page=${presentPage}-1)}">
-                                <i class="ci-arrow-left me-2"></i>Prev
+                            <a class="page-link" th:href="@{/members/myPage/wishlist(page=${presentPage})}">
+                                <i class="ci-arrow-left me-2"></i>
                             </a>
                         </li>
                     </ul>
@@ -111,24 +111,25 @@
                     <ul class="pagination">
                         <li class="page-item">
                             <a class="page-link" th:href="@{/members/myPage/wishlist(page=1)}">
-                                <i class="ci-arrow-left me-2"></i>First
+                                <i class="ci-arrow-left me-2"></i>
                             </a>
                         </li>
                     </ul>
 
-                    <ul class="pagination">
+                    <ul class="pagination row justify-content-center">
                         <th:block th:with="start = ${T(Math).floor(presentPage/10) * 10 +1},
                                             end = (${start + 9 < totalPages ? start+9 : totalPages})">
-                            <li class="page-item"
+                            <li class="page-item col-1 d-flex"
                                 th:each="pageButton : ${#numbers.sequence(start, end)}">
                                 <a class="page-link" th:classappend="( ${ pageButton == presentPage + 1 }) ? 'bg-primary text-white'  : '' " th:href="@{/members/myPage/wishlist(page = ${pageButton})}" th:text="${pageButton}"></a>
                             </li>
                         </th:block>
                     </ul>
 
-                    <ul class="pagination">
+
+                    <ul class="pagination ps-4">
                         <li class="page-item">
-                            <a class="page-link"th:href="@{/members/myPage/wishlist(page=${totalPages})}" aria-label="Next">Last
+                            <a class="page-link"th:href="@{/members/myPage/wishlist(page=${totalPages})}" aria-label="Next">
                                 <i class="ci-arrow-right ms-2"></i>
                             </a>
                         </li>
@@ -136,7 +137,7 @@
 
                     <ul class="pagination">
                         <li class="page-item">
-                            <a class="page-link"th:href="@{/members/myPage/wishlist(page=${presentPage}+1)}" aria-label="Next">Next
+                            <a class="page-link"th:href="@{/members/myPage/wishlist(page=${presentPage + 2 > totalPages ? presentPage + 1: presentPage + 2})}" aria-label="Next">
                                 <i class="ci-arrow-right ms-2"></i>
                             </a>
                         </li>

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -190,7 +190,7 @@
                 <ul class="pagination">
                     <li class="page-item">
                         <a class="page-link"
-                           th:href="@{/shop( first=${first},second=${second},keyword=${keyword}, page=${presentPage + 2})}"
+                           th:href="@{/shop( first=${first},second=${second},keyword=${keyword}, page=${presentPage + 2 > totalPages ? presentPage + 1: presentPage + 2})}"
                            aria-label="Next">
                             <i class="ci-arrow-right ms-2"></i>
                         </a>


### PR DESCRIPTION
shop페이지에서
![image](https://user-images.githubusercontent.com/75112818/196686434-6a460433-b408-4f1f-9201-c552a3070816.png)
위와 같이 카테고리 버튼 추가, 클릭시 카테고리 사이드바가 보이게 된다.

++추가 수정사항
shop 페이지를 제외한 다른 페이지네이션 바 버튼 prev 버튼 next 버튼 버그 수정
